### PR TITLE
Create Swagger API documentation #72

### DIFF
--- a/.idea/dataSources.xml
+++ b/.idea/dataSources.xml
@@ -9,6 +9,21 @@
       <jdbc-additional-properties>
         <property name="com.intellij.clouds.kubernetes.db.host.port" />
         <property name="com.intellij.clouds.kubernetes.db.enabled" value="false" />
+        <property name="com.intellij.clouds.kubernetes.db.resource.type" value="Deployment" />
+        <property name="com.intellij.clouds.kubernetes.db.container.port" />
+      </jdbc-additional-properties>
+      <working-dir>$ProjectFileDir$</working-dir>
+    </data-source>
+    <data-source source="LOCAL" name="authorization-db@localhost" uuid="7375ee8c-326d-4457-9084-bd0d2bc3dc83">
+      <driver-ref>postgresql</driver-ref>
+      <synchronize>true</synchronize>
+      <imported>true</imported>
+      <remarks>$PROJECT_DIR$/backend/authorization-service/src/main/resources/application.properties</remarks>
+      <jdbc-driver>org.postgresql.Driver</jdbc-driver>
+      <jdbc-url>jdbc:postgresql://localhost:5432/authorization-db?sslmode=disable</jdbc-url>
+      <jdbc-additional-properties>
+        <property name="com.intellij.clouds.kubernetes.db.host.port" />
+        <property name="com.intellij.clouds.kubernetes.db.enabled" value="false" />
         <property name="com.intellij.clouds.kubernetes.db.container.port" />
       </jdbc-additional-properties>
       <working-dir>$ProjectFileDir$</working-dir>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="EntryPointsManager">
+    <list size="1">
+      <item index="0" class="java.lang.String" itemvalue="io.swagger.v3.oas.annotations.Operation" />
+    </list>
+  </component>
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="FrameworkDetectionExcludesConfiguration">
     <file type="web" url="file://$PROJECT_DIR$/backend" />

--- a/README.md
+++ b/README.md
@@ -1,27 +1,38 @@
 # MaxQ Employee and Work Management Platform
 
-This application is a Mini Pet Project which allows for Employee and Work 
+This application is a Mini Pet Project which allows for Employee and Work
 Management.
 
 ## 🌐 Demo
 
 [Application Demo (Frontend)](http://employee-work-management.s3-website.eu-west-3.amazonaws.com/)
 
-**Demo Credentials (If applicable):**
-- **Username:** ReplaceThisWithUsername
-- **Password:** ReplaceThisWithPassword
+**Demo Credentials:**
+
+- **Username:** test@maxq.com
+- **Password:** Test12345
 
 ## 📖 About this Software
 
-Provide a comprehensive explanation of your software here. Dive into its core functionalities, why you opted to create it, its target users, and its value proposition.
+This application is an Employee and Work Management application to help with
+project and employees managing easier.
 
 ### Features:
 
-1. **Feature 1:** Brief description.
-2. **Feature 2:** Brief description.
-3. **...:** Continue listing out the core features of your application.
+1. **Authorization:** Application allows for registration and authorization
+   of users
+
+### Services:
+
+1. **Frontend:** Built using React + Typescript handles all client side
+   operations
+2. **Backend:** Backend is split into multiple microservices
+    * **Authorization Service:** Responsible for all authorization related
+      operations - registration and login -
+      see [API docs here](https://authorization-service-0h7q.onrender.com/swagger-ui.html)
 
 ### Technology stack
+
 * **Frontend:**
     * Typescript
     * React
@@ -35,24 +46,29 @@ Provide a comprehensive explanation of your software here. Dive into its core fu
     * Spring
     * Gradle
     * JUnit
+    * Swagger UI (API docs)
+* **API Testing:**
+    * Postman
+* **UI Testing:**
+    * PlaywrightTS
 * **CI/CD:**
     * GitHub Actions
 
 ### CI/CD Pipelines
 
-Several pipelines were created to allow automated integration, testing and 
+Several pipelines were created to allow automated integration, testing and
 deployment:
 
-1. Frontend CI pipeline - installs dependencies, lints, formats, tests and 
-   builds the application. Two artifacts are provided - test report 
+1. Frontend CI pipeline - installs dependencies, lints, formats, tests and
+   builds the application. Two artifacts are provided - test report
    (including coverage) and build files.
-2. Backend CI pipeline - installs dependencies, lints, tests and builds the 
+2. Backend CI pipeline - installs dependencies, lints, tests and builds the
    application. Unit test report is published as artifact.
-3. API tests pipeline - after successfull build backend is tested with API 
+3. API tests pipeline - after successfull build backend is tested with API
    tests. Report is published as artifact.
-4. UI tests pipeline - if both API tests and Frontend CI pipeline is 
+4. UI tests pipeline - if both API tests and Frontend CI pipeline is
    successfull UI tests are triggered. Report is published as artifact
-5. Frontend CD pipeline - after successfull integration to main branch 
+5. Frontend CD pipeline - after successfull integration to main branch
    deployment will happen to AWS S3.
 
 ## 🖼️ Screenshots
@@ -60,7 +76,9 @@ deployment:
 To give you a visual overview of the application, here are some screenshots:
 
 ### [Feature or Page Name]
+
 ![Description of Image](http://link-to-your-image.com/image1.png)
 
 ### [Another Feature or Page Name]
+
 ![Description of Image](http://link-to-your-image.com/image2.png)

--- a/backend/authorization-service/build.gradle
+++ b/backend/authorization-service/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     implementation 'org.postgresql:postgresql'
     implementation 'com.google.code.gson:gson'
     implementation 'org.springframework.security:spring-security-oauth2-jose'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     annotationProcessor 'org.projectlombok:lombok'

--- a/backend/authorization-service/src/main/java/org/maxq/authorization/controller/LoginController.java
+++ b/backend/authorization-service/src/main/java/org/maxq/authorization/controller/LoginController.java
@@ -1,6 +1,7 @@
 package org.maxq.authorization.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.maxq.authorization.controller.api.LoginApi;
 import org.maxq.authorization.domain.dto.TokenDto;
 import org.maxq.authorization.service.TokenService;
 import org.springframework.http.ResponseEntity;
@@ -13,10 +14,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/login")
 @RequiredArgsConstructor
-public class LoginController {
+public class LoginController implements LoginApi {
 
   private final TokenService tokenService;
 
+  @Override
   @PostMapping
   public ResponseEntity<TokenDto> login(Authentication authentication) {
     UserDetails userDetails = (UserDetails) authentication.getPrincipal();

--- a/backend/authorization-service/src/main/java/org/maxq/authorization/controller/RegisterController.java
+++ b/backend/authorization-service/src/main/java/org/maxq/authorization/controller/RegisterController.java
@@ -24,6 +24,7 @@ public class RegisterController implements RegisterApi {
   private final UserService userService;
   private final UserMapper userMapper;
 
+  @Override
   @PostMapping
   public ResponseEntity<Void> register(@RequestBody @Valid UserDto userDto)
       throws DataValidationException, DuplicateEmailException {

--- a/backend/authorization-service/src/main/java/org/maxq/authorization/controller/RegisterController.java
+++ b/backend/authorization-service/src/main/java/org/maxq/authorization/controller/RegisterController.java
@@ -2,6 +2,7 @@ package org.maxq.authorization.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.maxq.authorization.controller.api.RegisterApi;
 import org.maxq.authorization.domain.User;
 import org.maxq.authorization.domain.dto.UserDto;
 import org.maxq.authorization.domain.exception.DataValidationException;
@@ -18,7 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/register")
 @RequiredArgsConstructor
-public class RegisterController {
+public class RegisterController implements RegisterApi {
 
   private final UserService userService;
   private final UserMapper userMapper;

--- a/backend/authorization-service/src/main/java/org/maxq/authorization/controller/api/LoginApi.java
+++ b/backend/authorization-service/src/main/java/org/maxq/authorization/controller/api/LoginApi.java
@@ -4,7 +4,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.maxq.authorization.domain.HttpErrorMessage;
@@ -20,13 +19,11 @@ public interface LoginApi {
       description = "Authenticate user and provide with JWT token in return",
       security = @SecurityRequirement(name = "basicAuth")
   )
-  @ApiResponses(value = {
-      @ApiResponse(responseCode = "200", description = "Successful authentication", content = {
-          @Content(mediaType = "application/json", schema = @Schema(implementation = TokenDto.class))
-      }),
-      @ApiResponse(responseCode = "401", description = "Invalid credentials", content = {
-          @Content(mediaType = "application/json", schema = @Schema(implementation = HttpErrorMessage.class))
-      })
+  @ApiResponse(responseCode = "200", description = "Successful authentication", content = {
+      @Content(mediaType = "application/json", schema = @Schema(implementation = TokenDto.class))
+  })
+  @ApiResponse(responseCode = "401", description = "Invalid credentials", content = {
+      @Content(mediaType = "application/json", schema = @Schema(implementation = HttpErrorMessage.class))
   })
   ResponseEntity<TokenDto> login(Authentication authentication);
 }

--- a/backend/authorization-service/src/main/java/org/maxq/authorization/controller/api/LoginApi.java
+++ b/backend/authorization-service/src/main/java/org/maxq/authorization/controller/api/LoginApi.java
@@ -1,0 +1,32 @@
+package org.maxq.authorization.controller.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.maxq.authorization.domain.HttpErrorMessage;
+import org.maxq.authorization.domain.dto.TokenDto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+
+@Tag(name = "Login API")
+public interface LoginApi {
+
+  @Operation(
+      summary = "User authentication",
+      description = "Authenticate user and provide with JWT token in return",
+      security = @SecurityRequirement(name = "basicAuth")
+  )
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "Successful authentication", content = {
+          @Content(mediaType = "application/json", schema = @Schema(implementation = TokenDto.class))
+      }),
+      @ApiResponse(responseCode = "401", description = "Invalid credentials", content = {
+          @Content(mediaType = "application/json", schema = @Schema(implementation = HttpErrorMessage.class))
+      })
+  })
+  ResponseEntity<TokenDto> login(Authentication authentication);
+}

--- a/backend/authorization-service/src/main/java/org/maxq/authorization/controller/api/RegisterApi.java
+++ b/backend/authorization-service/src/main/java/org/maxq/authorization/controller/api/RegisterApi.java
@@ -5,7 +5,6 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.maxq.authorization.domain.HttpErrorMessage;
@@ -24,11 +23,9 @@ public interface RegisterApi {
           + "Provide user as request body. "
           + "User in a body will be validated"
   )
-  @ApiResponses(value = {
-      @ApiResponse(responseCode = "201", description = "User registered successfully"),
-      @ApiResponse(responseCode = "400", description = "Error during registration process", content = {
-          @Content(mediaType = "application/json", schema = @Schema(implementation = HttpErrorMessage.class))
-      })
+  @ApiResponse(responseCode = "201", description = "User registered successfully")
+  @ApiResponse(responseCode = "400", description = "Error during registration process", content = {
+      @Content(mediaType = "application/json", schema = @Schema(implementation = HttpErrorMessage.class))
   })
   ResponseEntity<Void> register(
       @io.swagger.v3.oas.annotations.parameters.RequestBody(
@@ -36,7 +33,7 @@ public interface RegisterApi {
           content = @Content(
               mediaType = "application/json",
               schema = @Schema(implementation = UserDto.class),
-              examples = @ExampleObject(value = "{ \"email\": \"example@example.com\", " +
+              examples = @ExampleObject("{ \"email\": \"example@example.com\", " +
                   "\"password\": \"Example1234\" }")
           )
       )

--- a/backend/authorization-service/src/main/java/org/maxq/authorization/controller/api/RegisterApi.java
+++ b/backend/authorization-service/src/main/java/org/maxq/authorization/controller/api/RegisterApi.java
@@ -1,0 +1,44 @@
+package org.maxq.authorization.controller.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.maxq.authorization.domain.HttpErrorMessage;
+import org.maxq.authorization.domain.dto.UserDto;
+import org.maxq.authorization.domain.exception.DataValidationException;
+import org.maxq.authorization.domain.exception.DuplicateEmailException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Register API")
+public interface RegisterApi {
+
+  @Operation(
+      summary = "Register new user",
+      description = "Register new user in the authorization service. "
+          + "Provide user as request body. "
+          + "User in a body will be validated"
+  )
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "201", description = "User registered successfully"),
+      @ApiResponse(responseCode = "400", description = "Error during registration process", content = {
+          @Content(mediaType = "application/json", schema = @Schema(implementation = HttpErrorMessage.class))
+      })
+  })
+  ResponseEntity<Void> register(
+      @io.swagger.v3.oas.annotations.parameters.RequestBody(
+          description = "New user to register in application", required = true,
+          content = @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = UserDto.class),
+              examples = @ExampleObject(value = "{ \"email\": \"example@example.com\", " +
+                  "\"password\": \"Example1234\" }")
+          )
+      )
+      @RequestBody @Valid UserDto userDto) throws DataValidationException, DuplicateEmailException;
+}

--- a/backend/authorization-service/src/main/java/org/maxq/authorization/controller/config/OpenApiConfig.java
+++ b/backend/authorization-service/src/main/java/org/maxq/authorization/controller/config/OpenApiConfig.java
@@ -1,0 +1,30 @@
+package org.maxq.authorization.controller.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+  @Bean
+  public OpenAPI customOpenAPI() {
+    final String basicAuthSchemeName = "basicAuth";
+
+    return new OpenAPI()
+        .info(new Info()
+            .title("Authorization Service")
+            .version("1.0")
+            .description("Authorization related APIs service for MaxQ Work Manager"))
+        .addSecurityItem(new SecurityRequirement().addList(basicAuthSchemeName))
+        .components(new Components()
+            .addSecuritySchemes(basicAuthSchemeName, new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("basic")));
+  }
+
+}


### PR DESCRIPTION
Created Swagger API documentation for Authorization endpoints - updated dependencies with springdoc-openapi-starter-webmwv-ui dependency.

Split Controllers into Interface/Implementation (example LoginApi/LoginController) to declutter business logic from api declaration/documentation. All APIs are in /controller/api and all Implementations in /controller.

Added OpenAPI documentation for /login and /register mappings - SwaggerUI is available under /swagger-ui.html mapping, both locally and after deployment.

Updated REDME file with recent Authorization updates - please update README after implementing changes (if necessary)