### PR TITLE
Create confirm registration page #88

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import { Provider } from 'react-redux';
 import { setupStore } from './store';
 import DialogManager from './components/DialogManager.tsx';
 import LoginPage from './pages/LoginPage.tsx';
+import RegisterConfirmationPage from './pages/RegisterConfirmationPage.tsx';
 
 const router = createBrowserRouter([
   {
@@ -16,6 +17,7 @@ const router = createBrowserRouter([
     children: [
       { index: true, element: <></> },
       { path: '/register', element: <RegisterPage /> },
+      { path: '/register/confirm', element: <RegisterConfirmationPage /> },
       { path: '/login', element: <LoginPage /> },
     ],
   },

--- a/frontend/src/pages/RegisterConfirmationPage.tsx
+++ b/frontend/src/pages/RegisterConfirmationPage.tsx
@@ -1,0 +1,70 @@
+import {useNavigate, useSearchParams} from 'react-router-dom';
+import {useEffect} from 'react';
+import {v4 as uuidv4} from 'uuid';
+
+import LoadingSpinner from '../components/shared/LoadingSpinner.tsx';
+import {useAppDispatch} from '../hooks/useStore.tsx';
+import {useConfirmRegistration} from '../api/auth.ts';
+import {registerModal} from '../store/modalSlice.ts';
+
+/**
+ * Renders the Register Confirmation with a centered `LoadingSpinner` component, Confimration
+ * page is opened when navigating to /register/confirm?token={TOKEN}.
+ *
+ * On the page, the request is sent to Register API /register/confirm to enable the user. If
+ * this request will fail - a warning will appear. If it was success - a success message will show.
+ * In both cases the Page will navigate to main page.
+ */
+const RegisterConfirmationPage = () => {
+  const [searchParams] = useSearchParams();
+  const dispatch = useAppDispatch();
+  const navigate = useNavigate();
+
+  const { isSuccess, isError, error, mutate } = useConfirmRegistration();
+
+  useEffect(() => {
+    mutate({ token: searchParams.get('token') ?? '' });
+  }, [mutate, searchParams]);
+
+  useEffect(() => {
+    if (isSuccess) {
+      dispatch(
+        registerModal({
+          id: uuidv4(),
+          content: {
+            message: 'Verification was successfull - you can now login',
+            type: 'success',
+            hideTimeout: 30_000,
+          },
+        })
+      );
+    }
+
+    if (isError) {
+      dispatch(
+        registerModal({
+          id: uuidv4(),
+          content: {
+            message: error.message || 'Something went wrong',
+            type: 'error',
+          },
+        })
+      );
+    }
+  }, [dispatch, isSuccess, isError, error]);
+
+  useEffect(() => {
+    if (isSuccess || isError) {
+      navigate('/');
+    }
+  });
+
+  return (
+    <div className="flex flex-grow items-center justify-center w-full">
+      {searchParams.get('token')}
+      <LoadingSpinner size="large" />
+    </div>
+  );
+};
+
+export default RegisterConfirmationPage;

--- a/frontend/tests/api/auth.test.tsx
+++ b/frontend/tests/api/auth.test.tsx
@@ -1,8 +1,10 @@
-import { afterEach, describe } from 'vitest';
+import { afterEach, describe, expect } from 'vitest';
 
 import {
+  confirmRegistration,
   login,
   register,
+  useConfirmRegistration,
   useLoginUser,
   useRegisterUser,
 } from '../../src/api/auth.ts';
@@ -141,6 +143,167 @@ describe('Authorization tests', () => {
         await expect(
           result.current.mutateAsync({ data: mockData })
         ).rejects.toThrowError(errorMessage);
+        await waitFor(() => {
+          expect(result.current.isError).toBe(true);
+        });
+      });
+    });
+  });
+
+  describe('Registration Verification', () => {
+    const mockToken = 'test';
+
+    describe('confirmRegistration', () => {
+      it('Should confirm successfully', async () => {
+        // Given
+        global.fetch = vi.fn().mockResolvedValue({
+          ok: true,
+          status: 200,
+        });
+
+        // When
+        await expect(
+          confirmRegistration({ token: mockToken })
+        ).resolves.not.toThrow();
+
+        // Then
+        expect(fetch).toHaveBeenCalledWith(
+          expect.stringContaining('/register/confirm?token=' + mockToken),
+          expect.objectContaining({
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+          })
+        );
+      });
+
+      it('Should handle API error with message', async () => {
+        // Given
+        const errorMessage = 'Verification error';
+        global.fetch = vi.fn().mockResolvedValue({
+          ok: false,
+          status: 400,
+          json: () => Promise.resolve({ message: errorMessage }),
+        });
+
+        // When
+
+        // Then
+        await expect(confirmRegistration({ token: mockToken })).rejects.toThrow(
+          'Error during verification process, try again later'
+        );
+      });
+
+      it('Should handle API verification expiration', async () => {
+        // Given
+        const errorMessage = 'Verification error';
+        global.fetch = vi.fn().mockResolvedValue({
+          ok: false,
+          status: 422,
+          json: () => Promise.resolve({ message: errorMessage }),
+        });
+
+        // When
+
+        // Then
+        await expect(confirmRegistration({ token: mockToken })).rejects.toThrow(
+          'Token is expired - sent a new one'
+        );
+      });
+
+      it('Should handle fetch rejects', async () => {
+        // Given
+        global.fetch = vi.fn().mockRejectedValue(new Error('Network error'));
+
+        // When
+
+        // Then
+        await expect(confirmRegistration({ token: mockToken })).rejects.toThrow(
+          'Network error'
+        );
+      });
+
+      it('Should handle non-API error', async () => {
+        // Given
+        global.fetch = vi.fn().mockResolvedValue({
+          ok: false,
+          status: 400,
+          json: () => Promise.resolve('API is down!'),
+        });
+
+        // When
+
+        // Then
+        await expect(confirmRegistration({ token: mockToken })).rejects.toThrow(
+          'Error during verification process, try again later'
+        );
+      });
+    });
+
+    describe('useConfirmRegistration hook', () => {
+      it('Should handle successful registration', async () => {
+        // Given
+        global.fetch = vi.fn().mockResolvedValue({
+          ok: true,
+          status: 200,
+        });
+
+        // When
+        const { result } = renderHook(() => useConfirmRegistration(), {
+          wrapper: queryWrapper,
+        });
+        result.current.mutate({ token: mockToken });
+
+        // Then
+        await waitFor(() => {
+          expect(result.current.isSuccess).toBe(true);
+        });
+      });
+
+      it('Should handle error in a hook', async () => {
+        // Given
+        const errorMessage = 'Registration failed';
+        global.fetch = vi.fn().mockResolvedValue({
+          ok: false,
+          status: 400,
+          json: () => Promise.resolve({ message: errorMessage }),
+        });
+
+        // When
+        const { result } = renderHook(() => useConfirmRegistration(), {
+          wrapper: queryWrapper,
+        });
+
+        // Then
+        await expect(
+          result.current.mutateAsync({ token: mockToken })
+        ).rejects.toThrowError(
+          'Error during verification process, try again later'
+        );
+        await waitFor(() => {
+          expect(result.current.isError).toBe(true);
+        });
+      });
+
+      it('Should handle expiration error', async () => {
+        // Given
+        const errorMessage = 'Registration failed';
+        global.fetch = vi.fn().mockResolvedValue({
+          ok: false,
+          status: 422,
+          json: () => Promise.resolve({ message: errorMessage }),
+        });
+
+        // When
+        const { result } = renderHook(() => useConfirmRegistration(), {
+          wrapper: queryWrapper,
+        });
+
+        // Then
+        await expect(
+          result.current.mutateAsync({ token: mockToken })
+        ).rejects.toThrowError('Token is expired - sent a new one');
         await waitFor(() => {
           expect(result.current.isError).toBe(true);
         });

--- a/frontend/tests/pages/RegisterConfirmationPage.test.tsx
+++ b/frontend/tests/pages/RegisterConfirmationPage.test.tsx
@@ -1,0 +1,235 @@
+import { afterEach, beforeEach, describe, expect, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import {
+  QueryClient,
+  QueryClientProvider,
+  UseMutationResult,
+} from '@tanstack/react-query';
+import { ReactNode } from 'react';
+import { Provider } from 'react-redux';
+import { BrowserRouter, useNavigate, useSearchParams } from 'react-router-dom';
+
+import RegisterConfirmationPage from '../../src/pages/RegisterConfirmationPage.tsx';
+import { setupStore } from '../../src/store';
+import * as auth from '../../src/api/auth.ts';
+import * as store from '../../src/hooks/useStore.tsx';
+
+vi.mock('react-router-dom', async () => {
+  const reactRouter = await vi.importActual('react-router-dom');
+  return {
+    ...reactRouter,
+    useNavigate: vi.fn(),
+    useSearchParams: vi.fn(),
+  };
+});
+
+const testWrapper = ({ children }: { children: ReactNode }) => {
+  const queryClient = new QueryClient();
+  return (
+    <Provider store={setupStore()}>
+      <QueryClientProvider client={queryClient}>
+        <BrowserRouter>{children}</BrowserRouter>
+      </QueryClientProvider>
+    </Provider>
+  );
+};
+
+describe('RegisterConfirmationPage', () => {
+  const mockMutate = vi.fn();
+  const mockNavigate = vi.fn();
+  const mockDispatch = vi.fn();
+
+  beforeEach(() => {
+    vi.resetModules();
+
+    vi.spyOn(auth, 'useConfirmRegistration').mockReturnValue({
+      mutate: mockMutate,
+      isSuccess: false,
+      isError: false,
+      isPending: false,
+      error: null,
+    } as unknown as UseMutationResult<void, Error, auth.ConfirmRequest>);
+
+    vi.spyOn(store, 'useAppDispatch').mockReturnValue(mockDispatch);
+
+    const mockUrlParams = new URLSearchParams('?token=test-token');
+    vi.mocked(useSearchParams).mockReturnValue([mockUrlParams, vi.fn()]);
+
+    vi.mocked(useNavigate).mockReturnValue(mockNavigate);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('Should render LoadingSpinner by default', () => {
+    // Given
+
+    // When
+    render(<RegisterConfirmationPage />, { wrapper: testWrapper });
+    const loadingSpinner = screen.getByTestId('spinner');
+
+    // Then
+    expect(loadingSpinner).toBeInTheDocument();
+  });
+
+  it('Should trigger confirmation check when loaded', async () => {
+    // Given
+
+    // When
+    render(<RegisterConfirmationPage />, { wrapper: testWrapper });
+
+    // Then
+    await waitFor(() => {
+      expect(mockMutate).toHaveBeenCalledOnce();
+      expect(mockMutate).toHaveBeenCalledWith({ token: 'test-token' });
+    });
+  });
+
+  describe('Navigation after confirmation', () => {
+    it('Should navigate home on success', async () => {
+      // Given
+      vi.spyOn(auth, 'useConfirmRegistration').mockReturnValue({
+        mutate: mockMutate,
+        isSuccess: true,
+        isError: false,
+        isPending: false,
+        error: null,
+      } as unknown as UseMutationResult<void, Error, auth.ConfirmRequest>);
+
+      // When
+      render(<RegisterConfirmationPage />, { wrapper: testWrapper });
+
+      // Then
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledOnce();
+        expect(mockNavigate).toHaveBeenCalledWith('/');
+      });
+    });
+
+    it('Should navigate home on error', async () => {
+      // Given
+      vi.spyOn(auth, 'useConfirmRegistration').mockReturnValue({
+        mutate: mockMutate,
+        isSuccess: false,
+        isError: true,
+        isPending: false,
+        error: new Error('Test Error'),
+      } as unknown as UseMutationResult<void, Error, auth.ConfirmRequest>);
+
+      // When
+      render(<RegisterConfirmationPage />, { wrapper: testWrapper });
+
+      // Then
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledOnce();
+        expect(mockNavigate).toHaveBeenCalledWith('/');
+      });
+    });
+  });
+
+  describe('Modals after confirmation', () => {
+    it('Should show success', async () => {
+      // Given
+      vi.spyOn(auth, 'useConfirmRegistration').mockReturnValue({
+        mutate: mockMutate,
+        isSuccess: true,
+        isError: false,
+        isPending: false,
+        error: null,
+      } as unknown as UseMutationResult<void, Error, auth.ConfirmRequest>);
+
+      // When
+      render(<RegisterConfirmationPage />, { wrapper: testWrapper });
+
+      // Then
+      await waitFor(() => {
+        expect(mockDispatch).toHaveBeenCalledOnce();
+        expect(mockDispatch).toHaveBeenCalledWith(
+          expect.objectContaining({
+            type: 'modal/registerModal',
+          })
+        );
+        expect(mockDispatch).toHaveBeenCalledWith(
+          expect.objectContaining<Record<string, unknown>>({
+            payload: expect.objectContaining<Record<string, unknown>>({
+              content: {
+                message: 'Verification was successfull - you can now login',
+                type: 'success',
+                hideTimeout: 30000,
+              },
+            }),
+          })
+        );
+      });
+    });
+
+    it('Should show error', async () => {
+      // Given
+      vi.spyOn(auth, 'useConfirmRegistration').mockReturnValue({
+        mutate: mockMutate,
+        isSuccess: false,
+        isError: true,
+        isPending: false,
+        error: new Error('Test Error'),
+      } as unknown as UseMutationResult<void, Error, auth.ConfirmRequest>);
+
+      // When
+      render(<RegisterConfirmationPage />, { wrapper: testWrapper });
+
+      // Then
+      await waitFor(() => {
+        expect(mockDispatch).toHaveBeenCalledOnce();
+        expect(mockDispatch).toHaveBeenCalledWith(
+          expect.objectContaining({
+            type: 'modal/registerModal',
+          })
+        );
+        expect(mockDispatch).toHaveBeenCalledWith(
+          expect.objectContaining<Record<string, unknown>>({
+            payload: expect.objectContaining<Record<string, unknown>>({
+              content: {
+                message: 'Test Error',
+                type: 'error',
+              },
+            }),
+          })
+        );
+      });
+    });
+
+    it('Should show error with default message', async () => {
+      // Given
+      vi.spyOn(auth, 'useConfirmRegistration').mockReturnValue({
+        mutate: mockMutate,
+        isSuccess: false,
+        isError: true,
+        isPending: false,
+        error: new Error(),
+      } as unknown as UseMutationResult<void, Error, auth.ConfirmRequest>);
+
+      // When
+      render(<RegisterConfirmationPage />, { wrapper: testWrapper });
+
+      // Then
+      await waitFor(() => {
+        expect(mockDispatch).toHaveBeenCalledOnce();
+        expect(mockDispatch).toHaveBeenCalledWith(
+          expect.objectContaining({
+            type: 'modal/registerModal',
+          })
+        );
+        expect(mockDispatch).toHaveBeenCalledWith(
+          expect.objectContaining<Record<string, unknown>>({
+            payload: expect.objectContaining<Record<string, unknown>>({
+              content: {
+                message: 'Something went wrong',
+                type: 'error',
+              },
+            }),
+          })
+        );
+      });
+    });
+  });
+});

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -9,6 +9,8 @@ export default defineConfig({
     include: ['./test[s]/**/*.{test,spec}.{js,jsx,ts,tsx}'],
     exclude: ['node_modules', 'dist', '.idea', '.git', '.cache'],
     coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html'],
       exclude: [
         'node_modules',
         'dist',
@@ -24,6 +26,7 @@ export default defineConfig({
         './src/vite-env.d.ts',
         'tests',
         'src/store/index.ts',
+        './docs',
       ],
     },
   },


### PR DESCRIPTION
Created Page that can be used to redirect from email to Confirm Registration.

The page handles /register/confirm API in Register API, shows information messages (errors or success) and then redirects home.