### PR TITLE
Email verification should be disabled on lower environments #89

### DIFF
--- a/.github/workflows/authorization-service-ci.yml
+++ b/.github/workflows/authorization-service-ci.yml
@@ -34,14 +34,20 @@ jobs:
 
       - name: Install dependencies
         run: ./gradlew clean authorization-service:build -x test -x check -x assemble -x pmdMain -x pmdTest
+        env:
+          SPRING_PROFILES_ACTIVE: QA
         working-directory: backend
 
       - name: Run Lint Checks
         run: ./gradlew authorization-service:check
+        env:
+          SPRING_PROFILES_ACTIVE: QA
         working-directory: backend
 
       - name: Run Unit Tests
         run: ./gradlew authorization-service:test
+        env:
+          SPRING_PROFILES_ACTIVE: QA
         working-directory: backend
 
       - name: Build
@@ -49,6 +55,7 @@ jobs:
         env:
           MAIL_USERNAME: ${{ secrets.MAIL_USERNAME }}
           MAIL_PASSWORD: ${{ secrets.MAIL_PASSWORD }}
+          SPRING_PROFILES_ACTIVE: PROD
         working-directory: backend
 
       - name: Upload Test Reports

--- a/.github/workflows/postman-authorization-service-ci.yml
+++ b/.github/workflows/postman-authorization-service-ci.yml
@@ -65,6 +65,7 @@ jobs:
         env:
           MAIL_USERNAME: ${{ secrets.MAIL_USERNAME }}
           MAIL_PASSWORD: ${{ secrets.MAIL_PASSWORD }}
+          SPRING_PROFILES_ACTIVE: QA
         working-directory: backend
 
       - name: Install Newman

--- a/.github/workflows/ui-tests-ci.yml
+++ b/.github/workflows/ui-tests-ci.yml
@@ -70,6 +70,8 @@ jobs:
         run: |
           chmod +x ./gradlew
           ./gradlew clean build
+        env:
+          SPRING_PROFILES_ACTIVE: QA
         working-directory: backend
 
       - name: Start Authorization Service
@@ -77,6 +79,7 @@ jobs:
         env:
           MAIL_USERNAME: ${{ secrets.MAIL_USERNAME }}
           MAIL_PASSWORD: ${{ secrets.MAIL_PASSWORD }}
+          SPRING_PROFILES_ACTIVE: QA
         working-directory: backend
 
       - name: Wait for application to be ready

--- a/backend/authorization-service/src/main/java/org/maxq/authorization/controller/QaController.java
+++ b/backend/authorization-service/src/main/java/org/maxq/authorization/controller/QaController.java
@@ -12,6 +12,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.LocalDateTime;
+
 @RestController
 @RequestMapping("/qa")
 @RequiredArgsConstructor
@@ -27,5 +29,11 @@ public class QaController implements QaApi {
     User user = userService.getUserByEmail(email);
     String token = verificationTokenService.getTokenByUser(user).getToken();
     return ResponseEntity.ok(token);
+  }
+
+  @Override
+  public ResponseEntity<Void> updateTokenCreationDate(String token, LocalDateTime creationDate) throws ElementNotFoundException {
+    verificationTokenService.updateCreationDate(token, creationDate);
+    return ResponseEntity.ok().build();
   }
 }

--- a/backend/authorization-service/src/main/java/org/maxq/authorization/controller/QaController.java
+++ b/backend/authorization-service/src/main/java/org/maxq/authorization/controller/QaController.java
@@ -1,0 +1,31 @@
+package org.maxq.authorization.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.maxq.authorization.controller.api.QaApi;
+import org.maxq.authorization.domain.User;
+import org.maxq.authorization.domain.exception.ElementNotFoundException;
+import org.maxq.authorization.service.UserService;
+import org.maxq.authorization.service.VerificationTokenService;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/qa")
+@RequiredArgsConstructor
+@Profile({"QA", "DEV"})
+public class QaController implements QaApi {
+
+  private final UserService userService;
+  private final VerificationTokenService verificationTokenService;
+
+  @Override
+  @GetMapping("/token")
+  public ResponseEntity<String> fetchNonExpiredVerificationTokenForUser(String email) throws ElementNotFoundException {
+    User user = userService.getUserByEmail(email);
+    String token = verificationTokenService.getTokenByUser(user).getToken();
+    return ResponseEntity.ok(token);
+  }
+}

--- a/backend/authorization-service/src/main/java/org/maxq/authorization/controller/api/QaApi.java
+++ b/backend/authorization-service/src/main/java/org/maxq/authorization/controller/api/QaApi.java
@@ -1,0 +1,10 @@
+package org.maxq.authorization.controller.api;
+
+import org.maxq.authorization.domain.exception.ElementNotFoundException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestParam;
+
+public interface QaApi {
+
+  ResponseEntity<String> fetchNonExpiredVerificationTokenForUser(@RequestParam String email) throws ElementNotFoundException;
+}

--- a/backend/authorization-service/src/main/java/org/maxq/authorization/controller/api/QaApi.java
+++ b/backend/authorization-service/src/main/java/org/maxq/authorization/controller/api/QaApi.java
@@ -1,10 +1,16 @@
 package org.maxq.authorization.controller.api;
 
+import jakarta.websocket.server.PathParam;
 import org.maxq.authorization.domain.exception.ElementNotFoundException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import java.time.LocalDateTime;
+
 public interface QaApi {
 
   ResponseEntity<String> fetchNonExpiredVerificationTokenForUser(@RequestParam String email) throws ElementNotFoundException;
+
+  ResponseEntity<Void> updateTokenCreationDate(@PathParam("token") String token,
+                                               @RequestParam LocalDateTime creationDate) throws ElementNotFoundException;
 }

--- a/backend/authorization-service/src/main/java/org/maxq/authorization/domain/VerificationToken.java
+++ b/backend/authorization-service/src/main/java/org/maxq/authorization/domain/VerificationToken.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.time.LocalDateTime;
 
@@ -30,6 +31,7 @@ public class VerificationToken {
   private User user;
 
   @Column(name = "CREATION_DATE")
+  @Setter
   private LocalDateTime creationDate;
 
   public VerificationToken(String token, User user, LocalDateTime creationDate) {

--- a/backend/authorization-service/src/main/java/org/maxq/authorization/event/listener/RegistrationListener.java
+++ b/backend/authorization-service/src/main/java/org/maxq/authorization/event/listener/RegistrationListener.java
@@ -4,8 +4,8 @@ import lombok.RequiredArgsConstructor;
 import org.maxq.authorization.domain.User;
 import org.maxq.authorization.domain.VerificationToken;
 import org.maxq.authorization.event.OnRegistrationComplete;
-import org.maxq.authorization.service.MailService;
 import org.maxq.authorization.service.VerificationTokenService;
+import org.maxq.authorization.service.mail.MailService;
 import org.springframework.context.ApplicationListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Component;
 public class RegistrationListener implements ApplicationListener<OnRegistrationComplete> {
 
   private final VerificationTokenService verificationTokenService;
-  private final MailService mailService;
+  private final MailService emailService;
 
   @Override
   @Async
@@ -24,7 +24,7 @@ public class RegistrationListener implements ApplicationListener<OnRegistrationC
 
     VerificationToken savedToken = verificationTokenService.createToken(user);
 
-    mailService.sendVerificationEmail(savedToken.getToken(), user.getEmail());
+    emailService.sendVerificationEmail(savedToken.getToken(), user.getEmail());
   }
 
   @Override

--- a/backend/authorization-service/src/main/java/org/maxq/authorization/repository/VerificationTokenRepository.java
+++ b/backend/authorization-service/src/main/java/org/maxq/authorization/repository/VerificationTokenRepository.java
@@ -1,13 +1,17 @@
 package org.maxq.authorization.repository;
 
+import org.maxq.authorization.domain.User;
 import org.maxq.authorization.domain.VerificationToken;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface VerificationTokenRepository extends CrudRepository<VerificationToken, Long> {
 
   Optional<VerificationToken> findByToken(String token);
+
+  List<VerificationToken> findAllByUser(User user);
 }

--- a/backend/authorization-service/src/main/java/org/maxq/authorization/service/VerificationTokenService.java
+++ b/backend/authorization-service/src/main/java/org/maxq/authorization/service/VerificationTokenService.java
@@ -8,6 +8,7 @@ import org.maxq.authorization.repository.VerificationTokenRepository;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -30,5 +31,15 @@ public class VerificationTokenService {
     Optional<VerificationToken> verificationToken = verificationTokenRepository.findByToken(token);
     return verificationToken.orElseThrow(() ->
         new ElementNotFoundException("Verification token was not found"));
+  }
+
+  public VerificationToken getTokenByUser(User user) throws ElementNotFoundException {
+    List<VerificationToken> tokens = verificationTokenRepository.findAllByUser(user);
+    return tokens.stream()
+        .filter(token ->
+            token.getCreationDate().plusMinutes(23L * 60).isAfter(LocalDateTime.now()))
+        .min((token1, token2) -> token2.getCreationDate().compareTo(token1.getCreationDate()))
+        .orElseThrow(() ->
+            new ElementNotFoundException("Verification token was not found"));
   }
 }

--- a/backend/authorization-service/src/main/java/org/maxq/authorization/service/VerificationTokenService.java
+++ b/backend/authorization-service/src/main/java/org/maxq/authorization/service/VerificationTokenService.java
@@ -42,4 +42,16 @@ public class VerificationTokenService {
         .orElseThrow(() ->
             new ElementNotFoundException("Verification token was not found"));
   }
+
+  public void updateCreationDate(String token, LocalDateTime creationDate) throws ElementNotFoundException {
+    Optional<VerificationToken> verificationToken = verificationTokenRepository.findByToken(token);
+
+    if (verificationToken.isEmpty()) {
+      throw new ElementNotFoundException("Verification token was not found");
+    }
+
+    VerificationToken updatedToken = verificationToken.get();
+    updatedToken.setCreationDate(creationDate);
+    verificationTokenRepository.save(updatedToken);
+  }
 }

--- a/backend/authorization-service/src/main/java/org/maxq/authorization/service/mail/MailCreatorService.java
+++ b/backend/authorization-service/src/main/java/org/maxq/authorization/service/mail/MailCreatorService.java
@@ -1,4 +1,4 @@
-package org.maxq.authorization.service;
+package org.maxq.authorization.service.mail;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;

--- a/backend/authorization-service/src/main/java/org/maxq/authorization/service/mail/MailService.java
+++ b/backend/authorization-service/src/main/java/org/maxq/authorization/service/mail/MailService.java
@@ -1,0 +1,5 @@
+package org.maxq.authorization.service.mail;
+
+public interface MailService {
+  void sendVerificationEmail(String email, String token);
+}

--- a/backend/authorization-service/src/main/java/org/maxq/authorization/service/mail/QAEmailService.java
+++ b/backend/authorization-service/src/main/java/org/maxq/authorization/service/mail/QAEmailService.java
@@ -1,0 +1,16 @@
+package org.maxq.authorization.service.mail;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+
+@Service
+@Profile("QA")
+@Slf4j
+public class QAEmailService implements MailService {
+
+  @Override
+  public void sendVerificationEmail(String token, String email) {
+    log.info("Email Service Stub - sending email to {} with token {}", email, token);
+  }
+}

--- a/backend/authorization-service/src/main/java/org/maxq/authorization/service/mail/TemplateEmailService.java
+++ b/backend/authorization-service/src/main/java/org/maxq/authorization/service/mail/TemplateEmailService.java
@@ -1,7 +1,8 @@
-package org.maxq.authorization.service;
+package org.maxq.authorization.service.mail;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.mail.javamail.MimeMessagePreparator;
@@ -10,13 +11,15 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 @Slf4j
-public class MailService {
+@Profile("!QA")
+public class TemplateEmailService implements MailService {
 
   private static final String SENDER = "noreply@maxq.com";
 
   private final JavaMailSender javaMailSender;
   private final MailCreatorService mailCreatorService;
 
+  @Override
   public void sendVerificationEmail(String token, String email) {
     String message = mailCreatorService.buildVerificationEmail(token, email);
     javaMailSender.send(

--- a/backend/authorization-service/src/test/java/org/maxq/authorization/controller/QaControllerTest.java
+++ b/backend/authorization-service/src/test/java/org/maxq/authorization/controller/QaControllerTest.java
@@ -1,0 +1,68 @@
+package org.maxq.authorization.controller;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.maxq.authorization.domain.User;
+import org.maxq.authorization.domain.VerificationToken;
+import org.maxq.authorization.service.UserService;
+import org.maxq.authorization.service.VerificationTokenService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.time.LocalDateTime;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+
+@WebAppConfiguration
+@SpringBootTest
+@ActiveProfiles("DEV")
+class QaControllerTest {
+
+  private static final String URL = "/qa";
+
+  private MockMvc mockMvc;
+
+  @Autowired
+  private WebApplicationContext webApplicationContext;
+
+  @MockBean
+  private UserService userService;
+  @MockBean
+  private VerificationTokenService verificationTokenService;
+
+  @BeforeEach
+  void securitySetup() {
+    mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
+        .apply(springSecurity())
+        .build();
+  }
+
+  @Test
+  void shouldReturnToken() throws Exception {
+    // Given
+    User user = new User("test@test.com", "test");
+    VerificationToken token = new VerificationToken(1L, "test", user, LocalDateTime.now());
+    when(userService.getUserByEmail("test@test.com")).thenReturn(user);
+    when(verificationTokenService.getTokenByUser(any(User.class))).thenReturn(token);
+
+    // When + Then
+    mockMvc.perform(MockMvcRequestBuilders
+            .get(URL + "/token")
+            .queryParam("email", user.getEmail()))
+        .andDo(print())
+        .andExpect(MockMvcResultMatchers.status().isOk())
+        .andExpect(MockMvcResultMatchers.jsonPath("$", Matchers.is(token.getToken())));
+  }
+}

--- a/backend/authorization-service/src/test/java/org/maxq/authorization/event/listener/RegistrationListenerTest.java
+++ b/backend/authorization-service/src/test/java/org/maxq/authorization/event/listener/RegistrationListenerTest.java
@@ -5,7 +5,7 @@ import org.maxq.authorization.domain.User;
 import org.maxq.authorization.domain.VerificationToken;
 import org.maxq.authorization.event.OnRegistrationComplete;
 import org.maxq.authorization.service.VerificationTokenService;
-import org.maxq.authorization.service.mail.TemplateEmailService;
+import org.maxq.authorization.service.mail.MailService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -31,7 +31,7 @@ class RegistrationListenerTest {
   @MockBean
   private VerificationTokenService verificationTokenService;
   @MockBean
-  private TemplateEmailService templateEmailService;
+  private MailService templateEmailService;
 
   @Test
   void shouldHandleRegistrationEvent() {

--- a/backend/authorization-service/src/test/java/org/maxq/authorization/event/listener/RegistrationListenerTest.java
+++ b/backend/authorization-service/src/test/java/org/maxq/authorization/event/listener/RegistrationListenerTest.java
@@ -4,8 +4,8 @@ import org.junit.jupiter.api.Test;
 import org.maxq.authorization.domain.User;
 import org.maxq.authorization.domain.VerificationToken;
 import org.maxq.authorization.event.OnRegistrationComplete;
-import org.maxq.authorization.service.MailService;
 import org.maxq.authorization.service.VerificationTokenService;
+import org.maxq.authorization.service.mail.TemplateEmailService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -31,7 +31,7 @@ class RegistrationListenerTest {
   @MockBean
   private VerificationTokenService verificationTokenService;
   @MockBean
-  private MailService mailService;
+  private TemplateEmailService templateEmailService;
 
   @Test
   void shouldHandleRegistrationEvent() {
@@ -47,7 +47,7 @@ class RegistrationListenerTest {
 
     // Then
     verify(verificationTokenService, times(1)).createToken(any(User.class));
-    verify(mailService, times(1)).sendVerificationEmail(token.getToken(), user.getEmail());
+    verify(templateEmailService, times(1)).sendVerificationEmail(token.getToken(), user.getEmail());
   }
 }
 

--- a/backend/authorization-service/src/test/java/org/maxq/authorization/repository/VerificationTokenRepositoryTest.java
+++ b/backend/authorization-service/src/test/java/org/maxq/authorization/repository/VerificationTokenRepositoryTest.java
@@ -10,10 +10,10 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.List;
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 class VerificationTokenRepositoryTest {
@@ -86,5 +86,25 @@ class VerificationTokenRepositoryTest {
 
     // Cleanup
     repository.deleteById(token1.getId());
+  }
+
+  @Test
+  void shouldReturnMultipleTokensForOneUser() {
+    // Given
+    VerificationToken token2 = new VerificationToken(2L, "token2", user, LocalDateTime.now());
+    repository.save(token2);
+
+    // when
+    List<VerificationToken> foundTokens = repository.findAllByUser(user);
+
+    // Then
+    assertAll(() -> {
+      assertEquals(2, foundTokens.size(), "Wrong number of tokens found!");
+      assertEquals(token.getId(), foundTokens.get(0).getId(), "Token 1 was not found!");
+      assertEquals(token2.getId(), foundTokens.get(1).getId(), "Token 2 was not found!");
+    });
+
+    // Cleanup
+    repository.deleteById(token2.getId());
   }
 }

--- a/backend/authorization-service/src/test/java/org/maxq/authorization/repository/VerificationTokenRepositoryTest.java
+++ b/backend/authorization-service/src/test/java/org/maxq/authorization/repository/VerificationTokenRepositoryTest.java
@@ -31,7 +31,7 @@ class VerificationTokenRepositoryTest {
     user = new User("test@test.com", "test", false);
     userRepository.save(user);
 
-    token = new VerificationToken(1L, "token", user, LocalDateTime.now());
+    token = new VerificationToken("token", user, LocalDateTime.now());
     repository.save(token);
   }
 
@@ -91,7 +91,7 @@ class VerificationTokenRepositoryTest {
   @Test
   void shouldReturnMultipleTokensForOneUser() {
     // Given
-    VerificationToken token2 = new VerificationToken(2L, "token2", user, LocalDateTime.now());
+    VerificationToken token2 = new VerificationToken("token2", user, LocalDateTime.now());
     repository.save(token2);
 
     // when

--- a/backend/authorization-service/src/test/java/org/maxq/authorization/service/VerificationTokenServiceTest.java
+++ b/backend/authorization-service/src/test/java/org/maxq/authorization/service/VerificationTokenServiceTest.java
@@ -17,6 +17,8 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @SpringBootTest
@@ -113,6 +115,31 @@ class VerificationTokenServiceTest {
 
     // When
     Executable executable = () -> verificationTokenService.getTokenByUser(user);
+
+    // Then
+    assertThrows(ElementNotFoundException.class, executable);
+  }
+
+  @Test
+  void shouldUpdateToken() throws ElementNotFoundException {
+    // Given
+    when(verificationTokenRepository.findByToken(token.getToken())).thenReturn(Optional.of(token));
+
+    // When
+    LocalDateTime newDate = LocalDateTime.now().plusMinutes(10L);
+    verificationTokenService.updateCreationDate(token.getToken(), newDate);
+
+    // Then
+    verify(verificationTokenRepository).save(argThat(vt -> vt.getCreationDate().isEqual(newDate)));
+  }
+
+  @Test
+  void shouldThrow_When_TokenNotFound_DuringUpdate() {
+    // Given
+    when(verificationTokenRepository.findByToken(any(String.class))).thenReturn(Optional.empty());
+
+    // When
+    Executable executable = () -> verificationTokenService.updateCreationDate("token", LocalDateTime.now());
 
     // Then
     assertThrows(ElementNotFoundException.class, executable);

--- a/backend/authorization-service/src/test/java/org/maxq/authorization/service/mail/MailCreatorServiceTest.java
+++ b/backend/authorization-service/src/test/java/org/maxq/authorization/service/mail/MailCreatorServiceTest.java
@@ -1,4 +1,4 @@
-package org.maxq.authorization.service;
+package org.maxq.authorization.service.mail;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;

--- a/backend/authorization-service/src/test/java/org/maxq/authorization/service/mail/TemplateEmailServiceTest.java
+++ b/backend/authorization-service/src/test/java/org/maxq/authorization/service/mail/TemplateEmailServiceTest.java
@@ -1,4 +1,4 @@
-package org.maxq.authorization.service;
+package org.maxq.authorization.service.mail;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,10 +11,10 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 @SpringBootTest
-class MailServiceTest {
+class TemplateEmailServiceTest {
 
   @Autowired
-  private MailService mailService;
+  private TemplateEmailService templateEmailService;
 
   @MockBean
   private JavaMailSender mailSender;
@@ -25,7 +25,7 @@ class MailServiceTest {
     doNothing().when(mailSender).send(any(MimeMessagePreparator.class));
 
     // When
-    mailService.sendVerificationEmail("token", "test@test.com");
+    templateEmailService.sendVerificationEmail("token", "test@test.com");
 
     // Then
     verify(mailSender, times(1)).send(any(MimeMessagePreparator.class));

--- a/backend/authorization-service/src/test/java/org/maxq/authorization/service/mail/TemplateEmailServiceTest.java
+++ b/backend/authorization-service/src/test/java/org/maxq/authorization/service/mail/TemplateEmailServiceTest.java
@@ -6,11 +6,13 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessagePreparator;
+import org.springframework.test.context.ActiveProfiles;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 @SpringBootTest
+@ActiveProfiles("DEV")
 class TemplateEmailServiceTest {
 
   @Autowired


### PR DESCRIPTION
Created new only QA and DEV endpoint - it allows to fetch newest token for a user (by email) and change creation date of a token. This will allow to test full flow of user registration.

Blocked execution of email service on QA environment - it will only log messages to log on Registration Event. This way emails will not clutter anything during automated QA. On DEV emails are sent normally, same as PROD.