### PR TITLE
Create /password/reset PATCH mapping in Login Controller #97

### DIFF
--- a/backend/authorization-service/src/main/java/org/maxq/authorization/controller/PasswordController.java
+++ b/backend/authorization-service/src/main/java/org/maxq/authorization/controller/PasswordController.java
@@ -2,25 +2,54 @@ package org.maxq.authorization.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.maxq.authorization.controller.api.PasswordApi;
+import org.maxq.authorization.domain.User;
+import org.maxq.authorization.domain.VerificationToken;
+import org.maxq.authorization.domain.exception.DataValidationException;
+import org.maxq.authorization.domain.exception.ElementNotFoundException;
+import org.maxq.authorization.domain.exception.ExpiredVerificationToken;
 import org.maxq.authorization.event.OnPasswordReset;
+import org.maxq.authorization.service.UserService;
+import org.maxq.authorization.service.VerificationTokenService;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Base64;
 
 @RestController
 @RequestMapping("/password")
 @RequiredArgsConstructor
 public class PasswordController implements PasswordApi {
 
+  private final UserService userService;
+  private final VerificationTokenService verificationTokenService;
   private final ApplicationEventPublisher eventPublisher;
+  private final PasswordEncoder passwordEncoder;
 
   @Override
   @PostMapping("/reset")
   public ResponseEntity<Void> resetPassword(@RequestParam String email) {
     eventPublisher.publishEvent(new OnPasswordReset(email));
+    return ResponseEntity.ok().build();
+  }
+
+  @Override
+  @PatchMapping("/reset")
+  public ResponseEntity<Void> updatePassword(@RequestParam String token, @RequestParam String password)
+      throws ElementNotFoundException, ExpiredVerificationToken, DataValidationException {
+    VerificationToken foundToken = verificationTokenService.getToken(token);
+
+    verificationTokenService.validateToken(foundToken);
+
+    User user = foundToken.getUser();
+    user.setPassword(
+        passwordEncoder.encode(
+            new String(Base64.getDecoder().decode(password.getBytes()))
+        )
+    );
+    userService.updateUser(user);
+
     return ResponseEntity.ok().build();
   }
 }

--- a/backend/authorization-service/src/main/java/org/maxq/authorization/controller/RegisterController.java
+++ b/backend/authorization-service/src/main/java/org/maxq/authorization/controller/RegisterController.java
@@ -19,14 +19,10 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.time.LocalDateTime;
-
 @RestController
 @RequestMapping("/register")
 @RequiredArgsConstructor
 public class RegisterController implements RegisterApi {
-
-  private static final Integer TOKEN_EXPIRATION_TIME = 60 * 24;
 
   private final UserService userService;
   private final VerificationTokenService verificationTokenService;
@@ -51,10 +47,11 @@ public class RegisterController implements RegisterApi {
       throws ElementNotFoundException, ExpiredVerificationToken, DataValidationException {
     VerificationToken foundToken = verificationTokenService.getToken(token);
 
-    LocalDateTime expirationTime = foundToken.getCreationDate().plusMinutes(TOKEN_EXPIRATION_TIME);
-    if (expirationTime.isBefore(LocalDateTime.now())) {
+    try {
+      verificationTokenService.validateToken(foundToken);
+    } catch (ExpiredVerificationToken e) {
       eventPublisher.publishEvent(new OnRegistrationComplete(foundToken.getUser()));
-      throw new ExpiredVerificationToken("Provided verification token expired at: " + expirationTime);
+      throw e;
     }
 
     User enabledUser = foundToken.getUser();

--- a/backend/authorization-service/src/main/java/org/maxq/authorization/controller/api/PasswordApi.java
+++ b/backend/authorization-service/src/main/java/org/maxq/authorization/controller/api/PasswordApi.java
@@ -1,8 +1,15 @@
 package org.maxq.authorization.controller.api;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.maxq.authorization.domain.HttpErrorMessage;
+import org.maxq.authorization.domain.exception.DataValidationException;
+import org.maxq.authorization.domain.exception.ElementNotFoundException;
+import org.maxq.authorization.domain.exception.ExpiredVerificationToken;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestParam;
 
@@ -16,4 +23,24 @@ public interface PasswordApi {
   )
   @ApiResponse(responseCode = "200", description = "Password reset should be sent successfully")
   ResponseEntity<Void> resetPassword(@RequestParam String email);
+
+  @Operation(
+      summary = "Sets new password for a user",
+      description = "When correct one-time verification token is provided this method will verify"
+          + " and change the password for the user the newly registered user. If token was used "
+          + " or expired a generic error will appear."
+  )
+  @ApiResponse(responseCode = "200", description = "Password reset successful")
+  @ApiResponse(responseCode = "400", description = "Error during password reset process",
+      content = {@Content(mediaType = "application/json", schema = @Schema(implementation = HttpErrorMessage.class))}
+  )
+  @ApiResponse(responseCode = "422", description = "Token expired", content = {
+      @Content(mediaType = "application/json", schema = @Schema(implementation = HttpErrorMessage.class))
+  })
+  ResponseEntity<Void> updatePassword(@RequestParam String token,
+                                      @Parameter(
+                                          required = true,
+                                          description = "Base64 encoded password"
+                                      ) @RequestParam String password)
+      throws ElementNotFoundException, ExpiredVerificationToken, DataValidationException;
 }

--- a/backend/authorization-service/src/main/java/org/maxq/authorization/domain/User.java
+++ b/backend/authorization-service/src/main/java/org/maxq/authorization/domain/User.java
@@ -27,6 +27,7 @@ public class User {
 
   @NotNull
   @Length(min = 4)
+  @Setter
   private String password;
 
   @NotNull

--- a/backend/authorization-service/src/main/java/org/maxq/authorization/service/VerificationTokenService.java
+++ b/backend/authorization-service/src/main/java/org/maxq/authorization/service/VerificationTokenService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.maxq.authorization.domain.User;
 import org.maxq.authorization.domain.VerificationToken;
 import org.maxq.authorization.domain.exception.ElementNotFoundException;
+import org.maxq.authorization.domain.exception.ExpiredVerificationToken;
 import org.maxq.authorization.repository.VerificationTokenRepository;
 import org.springframework.stereotype.Service;
 
@@ -16,6 +17,7 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class VerificationTokenService {
 
+  private static final Integer TOKEN_EXPIRATION_TIME = 60 * 24;
   private static final String VERIFICATION_TOKEN_NOT_FOUND = "Verification token was not found";
 
   private final VerificationTokenRepository verificationTokenRepository;
@@ -55,5 +57,12 @@ public class VerificationTokenService {
     VerificationToken updatedToken = verificationToken.get();
     updatedToken.setCreationDate(creationDate);
     verificationTokenRepository.save(updatedToken);
+  }
+
+  public void validateToken(VerificationToken token) throws ExpiredVerificationToken {
+    LocalDateTime expirationTime = token.getCreationDate().plusMinutes(TOKEN_EXPIRATION_TIME);
+    if (expirationTime.isBefore(LocalDateTime.now())) {
+      throw new ExpiredVerificationToken("Provided verification token expired at: " + expirationTime);
+    }
   }
 }

--- a/backend/authorization-service/src/test/java/org/maxq/authorization/controller/PasswordControllerTest.java
+++ b/backend/authorization-service/src/test/java/org/maxq/authorization/controller/PasswordControllerTest.java
@@ -1,20 +1,32 @@
 package org.maxq.authorization.controller;
 
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.maxq.authorization.config.MockitoPublisherConfiguration;
+import org.maxq.authorization.domain.User;
+import org.maxq.authorization.domain.VerificationToken;
+import org.maxq.authorization.domain.exception.DataValidationException;
+import org.maxq.authorization.domain.exception.ElementNotFoundException;
+import org.maxq.authorization.domain.exception.ExpiredVerificationToken;
 import org.maxq.authorization.event.OnPasswordReset;
+import org.maxq.authorization.service.UserService;
+import org.maxq.authorization.service.VerificationTokenService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Import;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
+
+import java.time.LocalDateTime;
+import java.util.Base64;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -36,12 +48,28 @@ class PasswordControllerTest {
 
   @MockBean
   private ApplicationEventPublisher eventPublisher;
+  @MockBean
+  private VerificationTokenService verificationTokenService;
+  @MockBean
+  private UserService userService;
+  @MockBean
+  private PasswordEncoder passwordEncoder;
+
+  private String password;
+  private String encodedPassword;
+  private VerificationToken token;
 
   @BeforeEach
-  void securitySetup() {
+  void setup() {
     mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
         .apply(springSecurity())
         .build();
+
+
+    password = "newPassword";
+    encodedPassword = Base64.getEncoder().encodeToString(password.getBytes());
+    User user = new User(1L, "test@test.com", "test", true);
+    token = new VerificationToken(1L, "test", user, LocalDateTime.now());
   }
 
   @Test
@@ -57,5 +85,89 @@ class PasswordControllerTest {
         .andExpect(MockMvcResultMatchers.status().isOk());
     verify(eventPublisher, times(1))
         .publishEvent(any(OnPasswordReset.class));
+  }
+
+  @Test
+  void shouldUpdatePassword() throws Exception {
+    // Given
+    when(verificationTokenService.getToken(token.getToken())).thenReturn(token);
+    doNothing().when(verificationTokenService).validateToken(any(VerificationToken.class));
+    when(passwordEncoder.encode(password)).thenReturn(password);
+
+    // When + Then
+    mockMvc.perform(MockMvcRequestBuilders
+            .patch(URL + RESET_URL)
+            .param("token", token.getToken())
+            .param("password", encodedPassword))
+        .andExpect(MockMvcResultMatchers.status().isOk());
+    verify(userService, times(1)).updateUser(any(User.class));
+    verify(userService).updateUser(argThat(updatedUser -> password.equals(updatedUser.getPassword())));
+  }
+
+  @Test
+  void shouldThrowException_When_TokenNotFound() throws Exception {
+    // Given
+    when(verificationTokenService.getToken(token.getToken()))
+        .thenThrow(new ElementNotFoundException("Test error"));
+
+    // When + Then
+    mockMvc.perform(MockMvcRequestBuilders
+            .patch(URL + RESET_URL)
+            .param("token", token.getToken())
+            .param("password", encodedPassword))
+        .andExpect(MockMvcResultMatchers.status().isNotFound())
+        .andExpect(MockMvcResultMatchers.jsonPath("$.message", Matchers.is("Test error")));
+  }
+
+  @Test
+  void shouldThrowException_When_TokenExpired() throws Exception {
+    // Given
+    when(verificationTokenService.getToken(token.getToken())).thenReturn(token);
+    doThrow(new ExpiredVerificationToken("Test error"))
+        .when(verificationTokenService).validateToken(any(VerificationToken.class));
+
+    // When + Then
+    mockMvc.perform(MockMvcRequestBuilders
+            .patch(URL + RESET_URL)
+            .param("token", token.getToken())
+            .param("password", encodedPassword))
+        .andExpect(MockMvcResultMatchers.status().isUnprocessableEntity())
+        .andExpect(MockMvcResultMatchers.jsonPath("$.message", Matchers.is("Test error")));
+  }
+
+  @Test
+  void shouldThrowException_When_PasswordNotValid() throws Exception {
+    // Given
+    when(verificationTokenService.getToken(token.getToken())).thenReturn(token);
+    doNothing().when(verificationTokenService).validateToken(any(VerificationToken.class));
+    doThrow(new DataValidationException("Test error", new Exception()))
+        .when(userService).updateUser(any(User.class));
+    when(passwordEncoder.encode(password)).thenReturn(password);
+
+    // When + Then
+    mockMvc.perform(MockMvcRequestBuilders
+            .patch(URL + RESET_URL)
+            .param("token", token.getToken())
+            .param("password", encodedPassword))
+        .andExpect(MockMvcResultMatchers.status().isBadRequest())
+        .andExpect(MockMvcResultMatchers.jsonPath("$.message", Matchers.is("Test error")));
+  }
+
+  @Test
+  void shouldThrowException_When_UserNotFound() throws Exception {
+    // Given
+    when(verificationTokenService.getToken(token.getToken())).thenReturn(token);
+    doNothing().when(verificationTokenService).validateToken(any(VerificationToken.class));
+    doThrow(new ElementNotFoundException("Test error"))
+        .when(userService).updateUser(any(User.class));
+    when(passwordEncoder.encode(password)).thenReturn(password);
+
+    // When + Then
+    mockMvc.perform(MockMvcRequestBuilders
+            .patch(URL + RESET_URL)
+            .param("token", token.getToken())
+            .param("password", encodedPassword))
+        .andExpect(MockMvcResultMatchers.status().isNotFound())
+        .andExpect(MockMvcResultMatchers.jsonPath("$.message", Matchers.is("Test error")));
   }
 }

--- a/backend/authorization-service/src/test/java/org/maxq/authorization/service/VerificationTokenServiceTest.java
+++ b/backend/authorization-service/src/test/java/org/maxq/authorization/service/VerificationTokenServiceTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.function.Executable;
 import org.maxq.authorization.domain.User;
 import org.maxq.authorization.domain.VerificationToken;
 import org.maxq.authorization.domain.exception.ElementNotFoundException;
+import org.maxq.authorization.domain.exception.ExpiredVerificationToken;
 import org.maxq.authorization.repository.VerificationTokenRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -143,5 +144,31 @@ class VerificationTokenServiceTest {
 
     // Then
     assertThrows(ElementNotFoundException.class, executable);
+  }
+
+  @Test
+  void shouldNotThrow_When_TokenNotExpired() {
+    // Given
+    VerificationToken nonExpiredToken = new VerificationToken(1L, "token", user,
+        LocalDateTime.now().minusMinutes(24 * 60).plusMinutes(1));
+
+    // When
+    Executable executable = () -> verificationTokenService.validateToken(nonExpiredToken);
+
+    // Then
+    assertDoesNotThrow(executable);
+  }
+
+  @Test
+  void shouldThrow_When_TokenExpired() {
+    // Given
+    VerificationToken nonExpiredToken = new VerificationToken(1L, "token", user,
+        LocalDateTime.now().minusMinutes(24 * 60).minusMinutes(1));
+
+    // When
+    Executable executable = () -> verificationTokenService.validateToken(nonExpiredToken);
+
+    // Then
+    assertThrows(ExpiredVerificationToken.class, executable);
   }
 }


### PR DESCRIPTION
Created password reset API in Password API. 

1. Updated VerificationTokenService to have a verification method, that could be used in all Controllers
2. Created /password/reset PATCH mapping in Password Controller - endpoint will fetch token (if exists), validate it and then update a user.