### PR TITLE
Add Role-based access control #141

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,15 @@ Management.
 
 **Demo Credentials:**
 
-- **Username:** test@maxq.com
-- **Password:** Test12345
+1. **Admin**:
+    - **username:** admin@maxq.com
+    - **password:** Admin12345
+2. **Operator**:
+    - **username:** operator@maxq.com
+    - **password:** Operator12345
+3. **Designer**:
+    - **username:** designer@maxq.com
+    - **password:** Designer12345
 
 ## 📖 About this Software
 
@@ -24,6 +31,8 @@ project and employees managing easier.
    will be sent to provided email. If verification expired a new one will be
    sent. Users can also request to reset their password from login page -
    this will send email to users with password reset.
+2. **Authentication:** Role-base authentication is in place, as default
+   three user roles are created - Admin, Operator and Designer.
 
 ### Services:
 
@@ -33,7 +42,8 @@ project and employees managing easier.
 2. **Backend:** Backend is split into multiple microservices
     * **Authorization Service:** Responsible for all authorization related
       operations - registration, registration verification, login -
-      see [API docs here](https://authorization-service-0h7q.onrender.com/swagger-ui.html)
+      see [API docs here](https://authorization-service-0h7q.onrender.com/swagger-ui.html).
+      Authorization service also provides role-based authentication.
 
 ### Technology stack
 

--- a/backend/authorization-service/src/main/java/org/maxq/authorization/init/RoleInitializer.java
+++ b/backend/authorization-service/src/main/java/org/maxq/authorization/init/RoleInitializer.java
@@ -5,11 +5,13 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.maxq.authorization.domain.Role;
 import org.maxq.authorization.repository.RoleRepository;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
 
-@Component
+@Component("roleInitializer")
+@ConditionalOnProperty(name = "app.init", havingValue = "true", matchIfMissing = true)
 @RequiredArgsConstructor
 @Slf4j
 public class RoleInitializer {

--- a/backend/authorization-service/src/main/java/org/maxq/authorization/init/UserInitializer.java
+++ b/backend/authorization-service/src/main/java/org/maxq/authorization/init/UserInitializer.java
@@ -3,33 +3,58 @@ package org.maxq.authorization.init;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.maxq.authorization.domain.Role;
 import org.maxq.authorization.domain.User;
+import org.maxq.authorization.domain.exception.ElementNotFoundException;
+import org.maxq.authorization.service.RoleService;
 import org.maxq.authorization.service.UserService;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
 @Slf4j
 public class UserInitializer {
-  private static final String TEST_EMAIL = "test@maxq.com";
-  private static final String TEST_PASSWORD = "Test12345";
+  private static final String ADMIN_EMAIL = "admin@maxq.com";
+  private static final String ADMIN_PASSWORD = "Admin12345";
+  private static final String OPERATOR_EMAIL = "operator@maxq.com";
+  private static final String OPERATOR_PASSWORD = "Operator12345";
+  private static final String DESIGNER_EMAIL = "designer@maxq.com";
+  private static final String DESIGNER_PASSWORD = "Designer12345";
 
   private final UserService userService;
+  private final RoleService roleService;
   private final PasswordEncoder passwordEncoder;
 
   @PostConstruct
-  public void init() {
+  public void init() throws ElementNotFoundException {
     log.info("Initializing users");
 
-    @SuppressWarnings("java:S6437")
-    User user = new User(TEST_EMAIL, passwordEncoder.encode(TEST_PASSWORD), true);
 
-    try {
-      userService.createUser(user);
-      log.info("Default user created");
-    } catch (Exception e) {
-      log.info("Default user already exists");
-    }
+    Role roleAdmin = roleService.findByName("ADMIN");
+    @SuppressWarnings("java:S6437")
+    User admin = new User(ADMIN_EMAIL, passwordEncoder.encode(ADMIN_PASSWORD), true);
+    admin.getRoles().add(roleAdmin);
+
+    Role roleOperator = roleService.findByName("OPERATOR");
+    @SuppressWarnings("java:S6437")
+    User operator = new User(OPERATOR_EMAIL, passwordEncoder.encode(OPERATOR_PASSWORD), true);
+    operator.getRoles().add(roleOperator);
+
+    Role roleDesigner = roleService.findByName("DESIGNER");
+    @SuppressWarnings("java:S6437")
+    User designer = new User(DESIGNER_EMAIL, passwordEncoder.encode(DESIGNER_PASSWORD), true);
+    designer.getRoles().add(roleDesigner);
+
+    List.of(admin, operator, designer).forEach(user -> {
+      try {
+        userService.createUser(user);
+        log.info("Default user created - {}", user.getRoles().getFirst().getName());
+      } catch (Exception e) {
+        log.info("Default {} user already exists", user.getRoles().getFirst().getName());
+      }
+    });
   }
 }

--- a/backend/authorization-service/src/main/java/org/maxq/authorization/init/UserInitializer.java
+++ b/backend/authorization-service/src/main/java/org/maxq/authorization/init/UserInitializer.java
@@ -8,12 +8,16 @@ import org.maxq.authorization.domain.User;
 import org.maxq.authorization.domain.exception.ElementNotFoundException;
 import org.maxq.authorization.service.RoleService;
 import org.maxq.authorization.service.UserService;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
 
 @Component
+@DependsOn("roleInitializer")
+@ConditionalOnProperty(name = "app.init", havingValue = "true", matchIfMissing = true)
 @RequiredArgsConstructor
 @Slf4j
 public class UserInitializer {
@@ -51,9 +55,9 @@ public class UserInitializer {
     List.of(admin, operator, designer).forEach(user -> {
       try {
         userService.createUser(user);
-        log.info("Default user created - {}", user.getRoles().getFirst().getName());
+        log.info("Default user created - {}", user.getEmail());
       } catch (Exception e) {
-        log.info("Default {} user already exists", user.getRoles().getFirst().getName());
+        log.info("Default {} user already exists", user.getEmail());
       }
     });
   }

--- a/backend/authorization-service/src/main/java/org/maxq/authorization/service/TokenService.java
+++ b/backend/authorization-service/src/main/java/org/maxq/authorization/service/TokenService.java
@@ -58,8 +58,6 @@ public class TokenService {
   public String generateToken(UserDetails userDetails) {
     List<String> roles = userDetails.getAuthorities().stream()
         .map(GrantedAuthority::getAuthority)
-        .map(role -> role.replace("ROLE_", ""))
-        .map(String::toLowerCase)
         .toList();
 
     JwtClaimsSet claimsSet = JwtClaimsSet.builder()

--- a/backend/authorization-service/src/test/java/org/maxq/authorization/service/TokenServiceTest.java
+++ b/backend/authorization-service/src/test/java/org/maxq/authorization/service/TokenServiceTest.java
@@ -55,9 +55,8 @@ class TokenServiceTest {
     } else {
       fail("Roles was not part of the UserDetails!");
     }
-    String mappedRole = role.replace("ROLE_", "").toLowerCase();
     String returnedRole = jwt.getClaimAsStringList("roles").getFirst();
-    assertEquals(mappedRole, returnedRole, "Correct role should be returned");
+    assertEquals(role, returnedRole, "Correct role should be returned");
   }
 }
 

--- a/backend/authorization-service/src/test/resources/application.properties
+++ b/backend/authorization-service/src/test/resources/application.properties
@@ -16,3 +16,4 @@ management.health.mail.enabled=false
 frontend.url=http://localhost:5173
 frontend.register.confirm.mapping=/register/confirm
 frontend.reset.password.mapping=/password/confirm
+app.init=false

--- a/postman-api-tests/authorization-service/EWM - Authorization Service.postman_collection.json
+++ b/postman-api-tests/authorization-service/EWM - Authorization Service.postman_collection.json
@@ -433,7 +433,7 @@
 					"name": "Positive",
 					"item": [
 						{
-							"name": "Login with existing credentials",
+							"name": "Login as admin",
 							"event": [
 								{
 									"listen": "test",
@@ -470,12 +470,140 @@
 									"basic": [
 										{
 											"key": "password",
-											"value": "{{enabledUserPassword}}",
+											"value": "{{adminPassword}}",
 											"type": "string"
 										},
 										{
 											"key": "username",
-											"value": "{{enabledUserEmail}}",
+											"value": "{{adminEmail}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "POST",
+								"header": [],
+								"url": {
+									"raw": "http://localhost:8081/login",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "8081",
+									"path": [
+										"login"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Login as operator",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", () => {\r",
+											"    pm.response.to.have.status(200);\r",
+											"});\r",
+											"\r",
+											"const response = pm.response.json();\r",
+											"\r",
+											"pm.test(\"Should containt token\", () => {\r",
+											"    pm.expect(response).to.haveOwnProperty('token').that.is.a('string');\r",
+											"})\r",
+											"\r",
+											"pm.test(\"Should be correct type\", () => {\r",
+											"    pm.expect(response).to.haveOwnProperty('type').that.is.a('string');\r",
+											"    pm.expect(response.type).to.eql('Bearer');\r",
+											"})\r",
+											"\r",
+											"pm.test(\"Should expire in 1h\", () => {\r",
+											"    pm.expect(response).to.haveOwnProperty('expiresIn').that.is.a('number');\r",
+											"    pm.expect(response.expiresIn).to.eql(3600);\r",
+											"})"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "basic",
+									"basic": [
+										{
+											"key": "password",
+											"value": "{{operatorPassword}}",
+											"type": "string"
+										},
+										{
+											"key": "username",
+											"value": "{{operatorEmail}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "POST",
+								"header": [],
+								"url": {
+									"raw": "http://localhost:8081/login",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "8081",
+									"path": [
+										"login"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Login as designer",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", () => {\r",
+											"    pm.response.to.have.status(200);\r",
+											"});\r",
+											"\r",
+											"const response = pm.response.json();\r",
+											"\r",
+											"pm.test(\"Should containt token\", () => {\r",
+											"    pm.expect(response).to.haveOwnProperty('token').that.is.a('string');\r",
+											"})\r",
+											"\r",
+											"pm.test(\"Should be correct type\", () => {\r",
+											"    pm.expect(response).to.haveOwnProperty('type').that.is.a('string');\r",
+											"    pm.expect(response.type).to.eql('Bearer');\r",
+											"})\r",
+											"\r",
+											"pm.test(\"Should expire in 1h\", () => {\r",
+											"    pm.expect(response).to.haveOwnProperty('expiresIn').that.is.a('number');\r",
+											"    pm.expect(response.expiresIn).to.eql(3600);\r",
+											"})"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "basic",
+									"basic": [
+										{
+											"key": "password",
+											"value": "{{designerPassword}}",
+											"type": "string"
+										},
+										{
+											"key": "username",
+											"value": "{{designerEmail}}",
 											"type": "string"
 										}
 									]
@@ -3242,13 +3370,13 @@
 			"value": ""
 		},
 		{
-			"key": "enabledUserEmail",
-			"value": "test@maxq.com",
+			"key": "adminEmail",
+			"value": "admin@maxq.com",
 			"type": "string"
 		},
 		{
-			"key": "enabledUserPassword",
-			"value": "Test12345",
+			"key": "adminPassword",
+			"value": "Admin12345",
 			"type": "string"
 		},
 		{
@@ -3331,6 +3459,26 @@
 		{
 			"key": "validVerificationToken",
 			"value": ""
+		},
+		{
+			"key": "operatorEmail",
+			"value": "operator@maxq.com",
+			"type": "string"
+		},
+		{
+			"key": "operatorPassword",
+			"value": "Operator12345",
+			"type": "string"
+		},
+		{
+			"key": "designerEmail",
+			"value": "designer@maxq.com",
+			"type": "string"
+		},
+		{
+			"key": "designerPassword",
+			"value": "Designer12345",
+			"type": "string"
 		}
 	]
 }

--- a/uitests/test-data/credentials.json
+++ b/uitests/test-data/credentials.json
@@ -1,6 +1,6 @@
 {
-  "user": {
-    "login": "test@maxq.com",
-    "password": "Test12345"
+  "admin": {
+    "login": "admin@maxq.com",
+    "password": "Admin12345"
   }
 }

--- a/uitests/tests/authorization/login/login.spec.ts
+++ b/uitests/tests/authorization/login/login.spec.ts
@@ -11,7 +11,7 @@ import {
 
 test("TC1 - should login with valid credentials", async ({ page, baseURL }) => {
   // Given
-  const userCredentials = credentials.user;
+  const userCredentials = credentials.admin;
 
   await openHomePage(page);
   await clickLoginButton(page);
@@ -29,7 +29,7 @@ test("TC1 - should login with valid credentials", async ({ page, baseURL }) => {
 });
 
 test("TC2 - should not login with invalid credentials", async ({ page }) => {
-  const userCredentials = credentials.user;
+  const userCredentials = credentials.admin;
 
   await openHomePage(page);
   await clickLoginButton(page);

--- a/uitests/tests/authorization/register/register.spec.ts
+++ b/uitests/tests/authorization/register/register.spec.ts
@@ -15,7 +15,7 @@ import {
 
 import credentials from "../../../test-data/credentials.json";
 
-const userCredentials = credentials.user;
+const userCredentials = credentials.admin;
 
 test("TC3 - should register with valid credentials", async ({
   page,


### PR DESCRIPTION
Added 3 main default users for all roles - admin, designer and operator. Users are generated during startup.

Added role based access control - for now login can be accessed by any role and other endpoints are public.

Updated API and UI tests to use new roles and also a README file.