### PR TITLE
[BE] Create GET /me request #162

### DIFF
--- a/backend/authorization-service/src/main/java/org/maxq/authorization/controller/LoginController.java
+++ b/backend/authorization-service/src/main/java/org/maxq/authorization/controller/LoginController.java
@@ -2,11 +2,18 @@ package org.maxq.authorization.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.maxq.authorization.controller.api.LoginApi;
+import org.maxq.authorization.domain.User;
+import org.maxq.authorization.domain.dto.MeDto;
 import org.maxq.authorization.domain.dto.TokenDto;
+import org.maxq.authorization.domain.exception.ElementNotFoundException;
+import org.maxq.authorization.mapper.UserMapper;
 import org.maxq.authorization.service.TokenService;
+import org.maxq.authorization.service.UserService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -17,6 +24,8 @@ import org.springframework.web.bind.annotation.RestController;
 public class LoginController implements LoginApi {
 
   private final TokenService tokenService;
+  private final UserService userService;
+  private final UserMapper userMapper;
 
   @Override
   @PostMapping
@@ -24,5 +33,13 @@ public class LoginController implements LoginApi {
     UserDetails userDetails = (UserDetails) authentication.getPrincipal();
     String token = tokenService.generateToken(userDetails);
     return ResponseEntity.ok(new TokenDto(token));
+  }
+
+  @Override
+  @GetMapping("/me")
+  public ResponseEntity<MeDto> me(Authentication authentication) throws ElementNotFoundException {
+    Jwt jwt = (Jwt) authentication.getPrincipal();
+    User user = userService.getUserByEmail(jwt.getSubject());
+    return ResponseEntity.ok(userMapper.mapToMeDto(user));
   }
 }

--- a/backend/authorization-service/src/main/java/org/maxq/authorization/controller/api/LoginApi.java
+++ b/backend/authorization-service/src/main/java/org/maxq/authorization/controller/api/LoginApi.java
@@ -7,7 +7,9 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.maxq.authorization.domain.HttpErrorMessage;
+import org.maxq.authorization.domain.dto.MeDto;
 import org.maxq.authorization.domain.dto.TokenDto;
+import org.maxq.authorization.domain.exception.ElementNotFoundException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 
@@ -27,4 +29,18 @@ public interface LoginApi {
           @Content(mediaType = "application/json", schema = @Schema(implementation = HttpErrorMessage.class))
       })
   ResponseEntity<TokenDto> login(Authentication authentication);
+
+  @Operation(
+      summary = "Authenticated user details",
+      description = "Authenticate user and provide with JWT token in return",
+      security = @SecurityRequirement(name = "JWT")
+  )
+  @ApiResponse(responseCode = "200", description = "Successful authentication", content = {
+      @Content(mediaType = "application/json", schema = @Schema(implementation = MeDto.class))
+  })
+  @ApiResponse(responseCode = "401", description = "Invalid JWT or account disabled",
+      content = {
+          @Content(mediaType = "application/json", schema = @Schema(implementation = HttpErrorMessage.class))
+      })
+  ResponseEntity<MeDto> me(Authentication authentication) throws ElementNotFoundException;
 }

--- a/backend/authorization-service/src/main/java/org/maxq/authorization/domain/dto/MeDto.java
+++ b/backend/authorization-service/src/main/java/org/maxq/authorization/domain/dto/MeDto.java
@@ -1,0 +1,16 @@
+package org.maxq.authorization.domain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class MeDto {
+
+  private String email;
+  private List<RoleDto> roles;
+}

--- a/backend/authorization-service/src/main/java/org/maxq/authorization/mapper/UserMapper.java
+++ b/backend/authorization-service/src/main/java/org/maxq/authorization/mapper/UserMapper.java
@@ -3,6 +3,7 @@ package org.maxq.authorization.mapper;
 import lombok.RequiredArgsConstructor;
 import org.maxq.authorization.domain.User;
 import org.maxq.authorization.domain.dto.GetUserDto;
+import org.maxq.authorization.domain.dto.MeDto;
 import org.maxq.authorization.domain.dto.UserDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -37,5 +38,12 @@ public class UserMapper {
         )
     ).toList();
     return new PageImpl<>(userDtoList, page, users.getTotalElements());
+  }
+
+  public MeDto mapToMeDto(User user) {
+    return new MeDto(
+        user.getEmail(),
+        roleMapper.mapToRoleDtoList(user.getRoles())
+    );
   }
 }

--- a/backend/authorization-service/src/main/java/org/maxq/authorization/security/config/WebSecurityConfig.java
+++ b/backend/authorization-service/src/main/java/org/maxq/authorization/security/config/WebSecurityConfig.java
@@ -80,6 +80,7 @@ public class WebSecurityConfig {
     http.securityMatcher("/**")
         .authorizeHttpRequests(
             authorizeRequests -> authorizeRequests
+                .requestMatchers("/login/me").authenticated()
                 .requestMatchers("/users/**").hasRole("ADMIN")
                 .requestMatchers("/roles/**").hasRole("ADMIN")
                 .anyRequest().permitAll())

--- a/backend/authorization-service/src/main/java/org/maxq/authorization/security/config/WebSecurityConfig.java
+++ b/backend/authorization-service/src/main/java/org/maxq/authorization/security/config/WebSecurityConfig.java
@@ -8,6 +8,7 @@ import org.maxq.authorization.service.UserService;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -57,10 +58,28 @@ public class WebSecurityConfig {
   }
 
   @Bean
-  public SecurityFilterChain filterChain(HttpSecurity http, RSAPublicKey publicKey) throws Exception {
-    http.authorizeHttpRequests(
+  @Order(1)
+  public SecurityFilterChain filterChainLogin(HttpSecurity http, RSAPublicKey publicKey) throws Exception {
+    http.securityMatcher("/login")
+        .authorizeHttpRequests(
             authorizeRequests -> authorizeRequests
-                .requestMatchers("/login").authenticated()
+                .requestMatchers("/login").authenticated())
+        .httpBasic(basic -> basic
+            .authenticationEntryPoint(authenticationFailureHandler()))
+        .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+        .csrf(AbstractHttpConfigurer::disable)
+        .exceptionHandling(exceptions -> exceptions
+            .authenticationEntryPoint(authenticationFailureHandler())
+            .accessDeniedHandler(accessDeniedHandler()));
+    return http.build();
+  }
+
+  @Bean
+  @Order(2)
+  public SecurityFilterChain filterChain(HttpSecurity http, RSAPublicKey publicKey) throws Exception {
+    http.securityMatcher("/**")
+        .authorizeHttpRequests(
+            authorizeRequests -> authorizeRequests
                 .requestMatchers("/users/**").hasRole("ADMIN")
                 .requestMatchers("/roles/**").hasRole("ADMIN")
                 .anyRequest().permitAll())
@@ -70,8 +89,6 @@ public class WebSecurityConfig {
                 .authenticationEntryPoint(authenticationFailureHandler()))
         .cors(cors -> cors.configurationSource(corsConfigurationSource()))
         .csrf(AbstractHttpConfigurer::disable)
-        .httpBasic(basic -> basic
-            .authenticationEntryPoint(authenticationFailureHandler()))
         .exceptionHandling(exceptions -> exceptions
             .authenticationEntryPoint(authenticationFailureHandler())
             .accessDeniedHandler(accessDeniedHandler()));

--- a/backend/authorization-service/src/test/java/org/maxq/authorization/mapper/UserMapperTest.java
+++ b/backend/authorization-service/src/test/java/org/maxq/authorization/mapper/UserMapperTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.maxq.authorization.domain.Role;
 import org.maxq.authorization.domain.User;
 import org.maxq.authorization.domain.dto.GetUserDto;
+import org.maxq.authorization.domain.dto.MeDto;
 import org.maxq.authorization.domain.dto.UserDto;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -66,6 +67,27 @@ class UserMapperTest {
             "Total elements should match after mapping"),
         () -> assertEquals(userPage.getTotalPages(), getUserDtoPage.getTotalPages(),
             "Total pages should match after mapping")
+    );
+  }
+
+  @Test
+  void shouldMapToMeDto() {
+    // Given
+    Role role = new Role(1L, "TEST", Collections.emptyList());
+    User user1 = new User(1L, "test1@test.com", "test1", false, Set.of(role));
+
+    // When
+    MeDto me = userMapper.mapToMeDto(user1);
+
+    // Then
+    assertAll(
+        () -> assertEquals(user1.getEmail(), me.getEmail(),
+            "User emails should match after mapping"),
+        () -> assertEquals(1, me.getRoles().size(), "Roles length not match after mapping"),
+        () -> assertEquals(role.getId(), me.getRoles().getFirst().getId(),
+            "Role ID not match after mapping"),
+        () -> assertEquals(role.getName(), me.getRoles().getFirst().getName(),
+            "Role name not match after mapping")
     );
   }
 }


### PR DESCRIPTION
Added GET /login/me in login controller API.

/me will return email and roles of a currently logged in user and requires JWT token - otherwise returns Authentication error.

Also fixed issue where Basic authorization was possible for all calls.
