### PR TITLE
[UIT] Add UI tests for role-base view #167

### DIFF
--- a/uitests/test-data/credentials.json
+++ b/uitests/test-data/credentials.json
@@ -2,5 +2,9 @@
   "admin": {
     "login": "admin@maxq.com",
     "password": "Admin12345"
+  },
+  "operator": {
+    "login": "operator@maxq.com",
+    "password": "Operator12345"
   }
 }

--- a/uitests/tests/admin/roles-update/rolesUpdate.spec.ts
+++ b/uitests/tests/admin/roles-update/rolesUpdate.spec.ts
@@ -164,3 +164,26 @@ test.describe("Update Roles", () => {
     });
   });
 });
+
+test("TC20 - should show error element when loader fails", async ({
+  adminPage,
+}) => {
+  // Given
+  await adminPage.route("**/users?*", async (route) => {
+    await route.fulfill({
+      status: 500,
+      contentType: "application/json",
+      body: JSON.stringify({
+        code: "InternalError",
+        message: "Internal Server Error",
+      }),
+    });
+  });
+
+  // When
+  await openRoleUpdatePage(adminPage);
+
+  // Then
+  await expect(adminPage.getByText("Error 500")).toBeVisible();
+  await expect(adminPage.getByText("Internal Server Error")).toBeVisible();
+});

--- a/uitests/tests/authorization/logout/admin.spec.ts
+++ b/uitests/tests/authorization/logout/admin.spec.ts
@@ -1,0 +1,15 @@
+import { expect, test } from "../../base/baseTest";
+import { openHomePage } from "../../utils/navigation.utils";
+
+test("TC21 - role elements should be hidden after logout", async ({
+  adminPage,
+}) => {
+  // Given
+  await openHomePage(adminPage);
+
+  // When
+  await adminPage.getByText("Logout").click();
+
+  // Then
+  await expect(adminPage.getByText("Admin", { exact: true })).toBeHidden();
+});

--- a/uitests/tests/authorization/roles/roles.spec.ts
+++ b/uitests/tests/authorization/roles/roles.spec.ts
@@ -1,6 +1,11 @@
 import { expect, test } from "../../base/baseTest";
 import { openAdminPage } from "../../utils/navigation.utils";
-import { notLoggedInMessage } from "./roles.utils";
+import { notAuthorizedMessage, notLoggedInMessage } from "./roles.utils";
+import { buildContextStorage, ContextState } from "../../setup/setup.utils";
+
+import credentials from "../../../test-data/credentials.json";
+import { loginApi } from "../../utils/api.utils";
+import { Page } from "playwright";
 
 test("TC18 - should navigate to login if user is not logged in", async ({
   page,
@@ -13,4 +18,38 @@ test("TC18 - should navigate to login if user is not logged in", async ({
   // Then
   await expect(page).toHaveURL("/login");
   await expect(notLoggedInMessage(page)).toBeVisible();
+});
+
+test("TC19 - should navigate to home if user is not authorized", async ({
+  browser,
+  apiContext,
+  baseURL,
+}) => {
+  let contextState: ContextState;
+
+  await test.step("TC-19.1 - create login state", async () => {
+    // Given
+    const userCredentials = credentials.operator;
+
+    // When
+    const token = await loginApi(apiContext, userCredentials);
+
+    // Then
+    expect(token).toBeDefined();
+    expect(token.token).toBeDefined();
+    contextState = buildContextStorage(baseURL, token);
+  });
+
+  let page: Page;
+  await test.step("TC-19.2 - navigate to not authorized page", async () => {
+    // Given
+    page = await browser.newPage({ storageState: contextState });
+
+    // When
+    await openAdminPage(page);
+
+    // Then
+    await expect(page).toHaveURL("/");
+    await expect(notAuthorizedMessage(page)).toBeVisible();
+  });
 });

--- a/uitests/tests/authorization/roles/roles.spec.ts
+++ b/uitests/tests/authorization/roles/roles.spec.ts
@@ -1,0 +1,16 @@
+import { expect, test } from "../../base/baseTest";
+import { openAdminPage } from "../../utils/navigation.utils";
+import { notLoggedInMessage } from "./roles.utils";
+
+test("TC18 - should navigate to login if user is not logged in", async ({
+  page,
+}) => {
+  // Given
+
+  // When
+  await openAdminPage(page);
+
+  // Then
+  await expect(page).toHaveURL("/login");
+  await expect(notLoggedInMessage(page)).toBeVisible();
+});

--- a/uitests/tests/authorization/roles/roles.utils.ts
+++ b/uitests/tests/authorization/roles/roles.utils.ts
@@ -3,3 +3,9 @@ import { Page } from "playwright";
 export const notLoggedInMessage = (page: Page) => {
   return page.getByText("You are not logged in! Please log in.");
 };
+
+export const notAuthorizedMessage = (page: Page) => {
+  return page.getByText(
+    "You are not authorized to access this page. Please log in.",
+  );
+};

--- a/uitests/tests/authorization/roles/roles.utils.ts
+++ b/uitests/tests/authorization/roles/roles.utils.ts
@@ -1,0 +1,5 @@
+import { Page } from "playwright";
+
+export const notLoggedInMessage = (page: Page) => {
+  return page.getByText("You are not logged in! Please log in.");
+};

--- a/uitests/tests/setup/setup.utils.ts
+++ b/uitests/tests/setup/setup.utils.ts
@@ -10,8 +10,19 @@ interface Origin {
   localStorage: Storage[];
 }
 
+interface Cookie {
+  name: string;
+  value: string;
+  domain: string;
+  path: string;
+  expires: number;
+  httpOnly: boolean;
+  secure: boolean;
+  sameSite: "Strict" | "Lax" | "None";
+}
+
 export interface ContextState {
-  cookies: object[];
+  cookies: Cookie[];
   origins: Origin[];
 }
 

--- a/uitests/tests/utils/navigation.utils.ts
+++ b/uitests/tests/utils/navigation.utils.ts
@@ -16,6 +16,10 @@ export const openUpdatePasswordPage = async (page: Page, token: string) => {
   await page.goto(`/password/confirm?token=${token}`);
 };
 
+export const openAdminPage = async (page: Page) => {
+  await page.goto("/admin");
+};
+
 export const openRoleUpdatePage = async (page: Page) => {
   await page.goto("/admin/roles-update");
 };


### PR DESCRIPTION
Added tests:

- TC18 - should navigate to login if user is not logged in
- TC19 - should navigate to home if user is not authorized
- TC20 - should show error when loader fails
- TC21 - should hide role specific elements on logout