### PR TITLE
[BE] Configure authorization-service to register in discovery-service #195

### DIFF
--- a/.github/workflows/authorization-service-cd.yml
+++ b/.github/workflows/authorization-service-cd.yml
@@ -47,7 +47,7 @@ jobs:
           file: ./backend/authorization-service/Dockerfile
           push: true
           tags: |
-            ${{ secrets.DOCKER_USERNAME }}/authorization-service:0.0.1
+            ${{ secrets.DOCKER_USERNAME }}/authorization-service:1.0.0
             ${{ secrets.DOCKER_USERNAME }}/authorization-service:latest
           labels: authorization-service
 

--- a/backend/authorization-service/build.gradle
+++ b/backend/authorization-service/build.gradle
@@ -1,12 +1,12 @@
 plugins {
     id 'java'
     id 'pmd'
-    id 'org.springframework.boot' version '3.3.5'
-    id 'io.spring.dependency-management' version '1.1.6'
+    id 'org.springframework.boot' version '3.5.4'
+    id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'org.maxq'
-version = '0.0.1-SNAPSHOT'
+version = '1.0.0'
 
 java {
     toolchain {
@@ -24,6 +24,10 @@ repositories {
     mavenCentral()
 }
 
+ext {
+    set('springCloudVersion', "2025.0.0")
+}
+
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
@@ -37,6 +41,7 @@ dependencies {
     implementation 'com.google.code.gson:gson'
     implementation 'org.springframework.security:spring-security-oauth2-jose'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
+    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     annotationProcessor 'org.projectlombok:lombok'
@@ -47,6 +52,12 @@ dependencies {
     testCompileOnly 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+    }
 }
 
 tasks.named('test') {

--- a/backend/authorization-service/src/main/resources/application.properties
+++ b/backend/authorization-service/src/main/resources/application.properties
@@ -17,6 +17,10 @@ spring.mail.password=${MAIL_PASSWORD}
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
 spring.mail.properties.mail.smtp.ssl.trust=smtp.gmail.com
+eureka.client.service-url.defaultZone=${EUREKA_URL:http://localhost:8761/eureka}
 frontend.url=${FRONTEND_URL:http://localhost:5173}
 frontend.register.confirm.mapping=/register/confirm
 frontend.reset.password.mapping=/password/confirm
+#---
+spring.config.activate.on-profile=QA
+eureka.client.enabled=false

--- a/backend/authorization-service/src/test/java/org/maxq/authorization/controller/LoginControllerTest.java
+++ b/backend/authorization-service/src/test/java/org/maxq/authorization/controller/LoginControllerTest.java
@@ -13,12 +13,12 @@ import org.maxq.authorization.service.TokenService;
 import org.maxq.authorization.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -47,14 +47,14 @@ class LoginControllerTest {
   @Autowired
   private WebApplicationContext webApplicationContext;
 
-  @MockBean
+  @MockitoBean
   private TokenService tokenService;
-  @MockBean
+  @MockitoBean
   private UserService userService;
-  @MockBean
+  @MockitoBean
   private UserMapper userMapper;
 
-  @MockBean
+  @MockitoBean
   private UserDetailsDbService userDetailsDbService;
 
   @BeforeEach

--- a/backend/authorization-service/src/test/java/org/maxq/authorization/controller/PasswordControllerTest.java
+++ b/backend/authorization-service/src/test/java/org/maxq/authorization/controller/PasswordControllerTest.java
@@ -15,10 +15,10 @@ import org.maxq.authorization.service.UserService;
 import org.maxq.authorization.service.VerificationTokenService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Import;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -49,13 +49,13 @@ class PasswordControllerTest {
   @Autowired
   private WebApplicationContext webApplicationContext;
 
-  @MockBean
+  @MockitoBean
   private ApplicationEventPublisher eventPublisher;
-  @MockBean
+  @MockitoBean
   private VerificationTokenService verificationTokenService;
-  @MockBean
+  @MockitoBean
   private UserService userService;
-  @MockBean
+  @MockitoBean
   private PasswordEncoder passwordEncoder;
 
   private String password;

--- a/backend/authorization-service/src/test/java/org/maxq/authorization/controller/QaControllerTest.java
+++ b/backend/authorization-service/src/test/java/org/maxq/authorization/controller/QaControllerTest.java
@@ -10,8 +10,8 @@ import org.maxq.authorization.service.UserService;
 import org.maxq.authorization.service.VerificationTokenService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -37,9 +37,9 @@ class QaControllerTest {
   @Autowired
   private WebApplicationContext webApplicationContext;
 
-  @MockBean
+  @MockitoBean
   private UserService userService;
-  @MockBean
+  @MockitoBean
   private VerificationTokenService verificationTokenService;
 
   @BeforeEach

--- a/backend/authorization-service/src/test/java/org/maxq/authorization/controller/RegisterControllerTest.java
+++ b/backend/authorization-service/src/test/java/org/maxq/authorization/controller/RegisterControllerTest.java
@@ -24,10 +24,10 @@ import org.maxq.authorization.service.UserService;
 import org.maxq.authorization.service.VerificationTokenService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -60,15 +60,15 @@ class RegisterControllerTest {
 
   @Autowired
   private WebApplicationContext webApplicationContext;
-  @MockBean
+  @MockitoBean
   private UserService userService;
-  @MockBean
+  @MockitoBean
   private RoleService roleService;
-  @MockBean
+  @MockitoBean
   private UserMapper userMapper;
-  @MockBean
+  @MockitoBean
   private ApplicationEventPublisher eventPublisher;
-  @MockBean
+  @MockitoBean
   private VerificationTokenService verificationTokenService;
 
   @BeforeEach

--- a/backend/authorization-service/src/test/java/org/maxq/authorization/controller/RoleControllerTest.java
+++ b/backend/authorization-service/src/test/java/org/maxq/authorization/controller/RoleControllerTest.java
@@ -9,8 +9,8 @@ import org.maxq.authorization.mapper.RoleMapper;
 import org.maxq.authorization.service.RoleService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -36,9 +36,9 @@ class RoleControllerTest {
   @Autowired
   private WebApplicationContext webApplicationContext;
 
-  @MockBean
+  @MockitoBean
   private RoleService roleService;
-  @MockBean
+  @MockitoBean
   private RoleMapper roleMapper;
 
   private Role role1;

--- a/backend/authorization-service/src/test/java/org/maxq/authorization/controller/UserControllerTest.java
+++ b/backend/authorization-service/src/test/java/org/maxq/authorization/controller/UserControllerTest.java
@@ -14,11 +14,11 @@ import org.maxq.authorization.mapper.UserMapper;
 import org.maxq.authorization.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -43,9 +43,9 @@ class UserControllerTest {
 
   @Autowired
   private WebApplicationContext webApplicationContext;
-  @MockBean
+  @MockitoBean
   private UserService userService;
-  @MockBean
+  @MockitoBean
   private UserMapper userMapper;
 
   private Role role;

--- a/backend/authorization-service/src/test/java/org/maxq/authorization/event/listener/PasswordResetListenerTest.java
+++ b/backend/authorization-service/src/test/java/org/maxq/authorization/event/listener/PasswordResetListenerTest.java
@@ -12,8 +12,8 @@ import org.maxq.authorization.service.VerificationTokenService;
 import org.maxq.authorization.service.mail.MailService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.time.LocalDateTime;
 import java.util.Collections;
@@ -29,11 +29,11 @@ class PasswordResetListenerTest {
   @Autowired
   private PasswordResetListener passwordResetListener;
 
-  @MockBean
+  @MockitoBean
   private UserService userService;
-  @MockBean
+  @MockitoBean
   private VerificationTokenService verificationTokenService;
-  @MockBean
+  @MockitoBean
   private MailService mailService;
 
   @Test

--- a/backend/authorization-service/src/test/java/org/maxq/authorization/event/listener/RegistrationListenerTest.java
+++ b/backend/authorization-service/src/test/java/org/maxq/authorization/event/listener/RegistrationListenerTest.java
@@ -10,8 +10,8 @@ import org.maxq.authorization.service.VerificationTokenService;
 import org.maxq.authorization.service.mail.MailService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.time.LocalDateTime;
 import java.util.Collections;
@@ -26,9 +26,9 @@ class RegistrationListenerTest {
   @Autowired
   private RegistrationListener registrationListener;
 
-  @MockBean
+  @MockitoBean
   private VerificationTokenService verificationTokenService;
-  @MockBean
+  @MockitoBean
   private MailService templateEmailService;
 
   @Test

--- a/backend/authorization-service/src/test/java/org/maxq/authorization/security/UserDetailsDbServiceTest.java
+++ b/backend/authorization-service/src/test/java/org/maxq/authorization/security/UserDetailsDbServiceTest.java
@@ -8,10 +8,10 @@ import org.maxq.authorization.domain.exception.ElementNotFoundException;
 import org.maxq.authorization.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.util.Collections;
 import java.util.List;
@@ -28,7 +28,7 @@ class UserDetailsDbServiceTest {
   @Autowired
   private UserDetailsDbService userDetailsDbService;
 
-  @MockBean
+  @MockitoBean
   private UserService userService;
 
   @Test

--- a/backend/authorization-service/src/test/java/org/maxq/authorization/service/RoleServiceTest.java
+++ b/backend/authorization-service/src/test/java/org/maxq/authorization/service/RoleServiceTest.java
@@ -9,8 +9,8 @@ import org.maxq.authorization.domain.exception.ElementNotFoundException;
 import org.maxq.authorization.repository.RoleRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.util.List;
 import java.util.Optional;
@@ -27,7 +27,7 @@ class RoleServiceTest {
   @Autowired
   private RoleService roleService;
 
-  @MockBean
+  @MockitoBean
   private RoleRepository roleRepository;
 
   private Role role;

--- a/backend/authorization-service/src/test/java/org/maxq/authorization/service/UserServiceTest.java
+++ b/backend/authorization-service/src/test/java/org/maxq/authorization/service/UserServiceTest.java
@@ -9,11 +9,11 @@ import org.maxq.authorization.domain.exception.*;
 import org.maxq.authorization.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.TransactionSystemException;
 
 import java.util.*;
@@ -27,9 +27,9 @@ class UserServiceTest {
   @Autowired
   private UserService userService;
 
-  @MockBean
+  @MockitoBean
   private UserRepository userRepository;
-  @MockBean
+  @MockitoBean
   private RoleService roleService;
 
   private User user;

--- a/backend/authorization-service/src/test/java/org/maxq/authorization/service/VerificationTokenServiceTest.java
+++ b/backend/authorization-service/src/test/java/org/maxq/authorization/service/VerificationTokenServiceTest.java
@@ -11,7 +11,7 @@ import org.maxq.authorization.domain.exception.ExpiredVerificationToken;
 import org.maxq.authorization.repository.VerificationTokenRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.time.LocalDateTime;
 import java.util.Collections;
@@ -30,7 +30,7 @@ class VerificationTokenServiceTest {
   @Autowired
   private VerificationTokenService verificationTokenService;
 
-  @MockBean
+  @MockitoBean
   private VerificationTokenRepository verificationTokenRepository;
 
   private User user;

--- a/backend/authorization-service/src/test/java/org/maxq/authorization/service/mail/TemplateEmailServiceTest.java
+++ b/backend/authorization-service/src/test/java/org/maxq/authorization/service/mail/TemplateEmailServiceTest.java
@@ -3,10 +3,10 @@ package org.maxq.authorization.service.mail;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessagePreparator;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -18,7 +18,7 @@ class TemplateEmailServiceTest {
   @Autowired
   private TemplateEmailService templateEmailService;
 
-  @MockBean
+  @MockitoBean
   private JavaMailSender mailSender;
 
   @Test

--- a/backend/authorization-service/src/test/resources/application.properties
+++ b/backend/authorization-service/src/test/resources/application.properties
@@ -5,6 +5,7 @@ spring.datasource.password=
 spring.jpa.database=h2
 spring.jpa.show-sql=true
 spring.jpa.hibernate.ddl-auto=update
+eureka.client.enabled=false
 jwt.issuer=authorization-service
 jwt.public-key-path=classpath:/public_key.pem
 jwt.private-key-path=classpath:/private_key.pem


### PR DESCRIPTION
Added Eureka client configuration to authorization-service

In tests - eureka client is disabled. This means either in QA environment for API tests or for Unit tests.

Eureka Client URL is taken from env variable EUREKA_URL or defaults to localhost.