### PR TITLE
[FE] Add editability option to profile page

### DIFF
--- a/frontend/src/components/icons/SaveIcon.tsx
+++ b/frontend/src/components/icons/SaveIcon.tsx
@@ -1,0 +1,23 @@
+import BaseIcon from './base/BaseIcon.tsx';
+import { IconProps } from '../../types/components/BaseTypes.ts';
+
+const SaveIcon = ({ className }: IconProps) => {
+  return (
+    <BaseIcon className={className}>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={2}
+        strokeLinecap="square"
+      >
+        <path d="M15.2 3a2 2 0 0 1 1.4.6l3.8 3.8a2 2 0 0 1 .6 1.4V19a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2z" />
+        <path d="M17 21v-7a1 1 0 0 0-1-1H8a1 1 0 0 0-1 1v7" />
+        <path d="M7 3v4a1 1 0 0 0 1 1h7" />
+      </svg>
+    </BaseIcon>
+  );
+};
+
+export default SaveIcon;

--- a/frontend/src/components/profile/Profile.tsx
+++ b/frontend/src/components/profile/Profile.tsx
@@ -10,15 +10,29 @@ import {
 import { useMyProfileQuery } from '../../store/api/profile.ts';
 import ProfileSection from './ProfileSection.tsx';
 import ProfileItem from './ProfileItem.tsx';
+import { FormEvent, useState } from 'react';
+import Form from '../shared/form/Form.tsx';
+import ProfileControls from './ProfileControls.tsx';
 
 const Profile = () => {
   const { data: profileData } = useMyProfileQuery();
+  const [isEdited, setIsEdited] = useState(false);
 
   const firstNameFirstLetter = profileData?.firstName.charAt(0) ?? 'M';
   const lastNameFirstLetter = profileData?.lastName.charAt(0) ?? 'Q';
   const imageFallback = (
     firstNameFirstLetter + lastNameFirstLetter
   ).toUpperCase();
+
+  const handleEdit = () => {
+    setIsEdited(true);
+  };
+  const handleCancel = () => {
+    setIsEdited(false);
+  };
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+  };
 
   return (
     <Flex direction="column" justify="center" align="center" m="6">
@@ -31,36 +45,57 @@ const Profile = () => {
         mb="6"
       />
       <Avatar size="9" radius="full" fallback={imageFallback} />
-      <Grid
-        columns={{ initial: '1', sm: '2' }}
-        width="100%"
-        mt="8"
-        gap="4"
-        align="start"
-      >
-        <ProfileSection title="Personal Information">
-          <Grid columns="2" gap="4" minHeight="0">
-            <ProfileItem isLoading={!profileData} title="First name">
-              {profileData?.firstName ?? ''}
-            </ProfileItem>
-            <ProfileItem isLoading={!profileData} title="Middle name">
-              {profileData?.middleName ?? ''}
-            </ProfileItem>
-            <Box gridColumnStart="1" gridColumnEnd="3">
-              <ProfileItem isLoading={!profileData} title="Last name">
-                {profileData?.lastName ?? ''}
+
+      <Form handleSubmit={handleSubmit} className="w-full">
+        <Grid
+          columns={{ initial: '1', sm: '2' }}
+          width="100%"
+          mt="8"
+          gap="4"
+          align="start"
+        >
+          <ProfileSection title="Personal Information">
+            <Grid columns="2" gap="4" minHeight="0">
+              <ProfileItem
+                isEdited={isEdited}
+                isLoading={!profileData}
+                title="First name"
+              >
+                {profileData?.firstName ?? ''}
               </ProfileItem>
-            </Box>
-          </Grid>
-        </ProfileSection>
-        <ProfileSection title="Email Address">
-          <ProfileItem isLoading={!profileData}>
-            <Link href={`mailto:${profileData?.email}`}>
-              {profileData?.email ?? ''}
-            </Link>
-          </ProfileItem>
-        </ProfileSection>
-      </Grid>
+              <ProfileItem
+                isEdited={isEdited}
+                isLoading={!profileData}
+                title="Middle name"
+              >
+                {profileData?.middleName ?? ''}
+              </ProfileItem>
+              <Box gridColumnStart="1" gridColumnEnd="3">
+                <ProfileItem
+                  isEdited={isEdited}
+                  isLoading={!profileData}
+                  title="Last name"
+                >
+                  {profileData?.lastName ?? ''}
+                </ProfileItem>
+              </Box>
+            </Grid>
+          </ProfileSection>
+          <ProfileSection title="Email Address">
+            <ProfileItem isEdited={false} isLoading={!profileData}>
+              <Link href={`mailto:${profileData?.email}`}>
+                {profileData?.email ?? ''}
+              </Link>
+            </ProfileItem>
+          </ProfileSection>
+
+          <ProfileControls
+            isEdited={isEdited}
+            onEdit={handleEdit}
+            onCancel={handleCancel}
+          />
+        </Grid>
+      </Form>
     </Flex>
   );
 };

--- a/frontend/src/components/profile/ProfileControls.tsx
+++ b/frontend/src/components/profile/ProfileControls.tsx
@@ -1,0 +1,47 @@
+import { Button, Flex } from '@radix-ui/themes';
+import { Cross2Icon, Pencil1Icon } from '@radix-ui/react-icons';
+import FormSubmit from '../shared/form/sub/FormSubmit.tsx';
+import SaveIcon from '../icons/SaveIcon.tsx';
+
+interface ProfileControlsProps {
+  isEdited: boolean;
+  onEdit: () => void;
+  onCancel: () => void;
+}
+
+const ProfileControls = ({
+  isEdited,
+  onEdit,
+  onCancel,
+}: ProfileControlsProps) => {
+  return (
+    <Flex
+      gridColumnStart="1"
+      gridColumnEnd="3"
+      justify="center"
+      align="center"
+      gap="2"
+    >
+      {!isEdited && (
+        <Button size="4" my="3" onClick={onEdit}>
+          <Pencil1Icon className="size-(--font-size-5)" /> Edit profile
+        </Button>
+      )}
+      {isEdited && (
+        <>
+          <FormSubmit
+            title="Save changes"
+            color="green"
+            width="fit"
+            icon={SaveIcon}
+          />
+          <Button size="4" color="gray" variant="soft" onClick={onCancel}>
+            <Cross2Icon className="size-(--font-size-5)" /> Cancel
+          </Button>
+        </>
+      )}
+    </Flex>
+  );
+};
+
+export default ProfileControls;

--- a/frontend/src/components/profile/ProfileItem.tsx
+++ b/frontend/src/components/profile/ProfileItem.tsx
@@ -1,24 +1,41 @@
 import { DataList, Skeleton } from '@radix-ui/themes';
 import { PropsWithChildren } from 'react';
+import { textContent } from '../../utils/reactChildren.ts';
+import FormInput from '../shared/form/sub/FormInput.tsx';
+import clsx from 'clsx/lite';
 
 interface ProfileItemProps {
+  isEdited: boolean;
   isLoading: boolean;
   title?: string;
 }
 
 const ProfileItem = ({
+  isEdited,
   isLoading,
   title,
   children,
 }: PropsWithChildren<ProfileItemProps>) => {
+  const itemClasses = clsx(
+    title && 'py-(--space-3)',
+    'font-(--font-weight-bold) text-(length:--font-size-3)'
+  );
+
   return (
     <DataList.Item>
       {title && <DataList.Label className="uppercase">{title}</DataList.Label>}
-      <Skeleton loading={isLoading}>
-        <DataList.Value className="font-(--font-weight-bold) text-(length:--font-size-3)">
-          {children}
-        </DataList.Value>
-      </Skeleton>
+      {!isEdited && (
+        <Skeleton loading={isLoading}>
+          <DataList.Value className={itemClasses}>{children}</DataList.Value>
+        </Skeleton>
+      )}
+      {isEdited && (
+        <FormInput
+          id={title}
+          placeholder={title}
+          defaultValue={textContent(children)}
+        ></FormInput>
+      )}
     </DataList.Item>
   );
 };

--- a/frontend/src/components/profile/ProfileSection.tsx
+++ b/frontend/src/components/profile/ProfileSection.tsx
@@ -19,7 +19,7 @@ const ProfileSection = ({
             {title}
           </Heading>
         </Flex>
-        <DataList.Root orientation="vertical" mt="4">
+        <DataList.Root orientation="vertical" mt="5">
           {children}
         </DataList.Root>
       </Box>

--- a/frontend/src/components/shared/form/Form.tsx
+++ b/frontend/src/components/shared/form/Form.tsx
@@ -9,13 +9,14 @@ import FormFooter from './sub/FormFooter.tsx';
 
 interface FormProps {
   handleSubmit: (event: FormEvent<HTMLFormElement>) => void;
+  className?: string;
 }
 
 const Form = (props: PropsWithChildren<FormProps>) => {
-  const { handleSubmit, children } = props;
+  const { handleSubmit, className, children } = props;
 
   return (
-    <RadixForm.Root onSubmit={handleSubmit}>
+    <RadixForm.Root onSubmit={handleSubmit} className={className}>
       <Flex
         direction="column"
         justify="center"

--- a/frontend/src/components/shared/form/sub/FormInput.tsx
+++ b/frontend/src/components/shared/form/sub/FormInput.tsx
@@ -26,7 +26,8 @@ const FormInput = (props: RadixFormInputProps) => {
   const EyeOpen = EyeOpenIcon;
 
   const {
-    name = 'field',
+    id,
+    name,
     type,
     max,
     min,
@@ -39,6 +40,7 @@ const FormInput = (props: RadixFormInputProps) => {
     onValueChange,
     ...rest
   } = props;
+  const fieldName = name ?? id ?? 'field';
   const [typeState, setTypeState] = useState(type);
 
   const EyeIcon = typeState === 'password' ? EyeClosed : EyeOpen;
@@ -62,7 +64,7 @@ const FormInput = (props: RadixFormInputProps) => {
   };
 
   return (
-    <Form.Field name={name} className="group w-full">
+    <Form.Field name={fieldName} className="group w-full">
       <Flex direction="column" gap="1">
         {name && (
           <Form.Label>
@@ -71,7 +73,7 @@ const FormInput = (props: RadixFormInputProps) => {
             </Text>
           </Form.Label>
         )}
-        <Form.ValidityState name={name}>
+        <Form.ValidityState name={fieldName}>
           {(validity) => {
             return (
               <Form.Control asChild>
@@ -85,7 +87,7 @@ const FormInput = (props: RadixFormInputProps) => {
                     onValueChange?.(event.currentTarget.value);
                   }}
                   type={typeState}
-                  name={name}
+                  name={fieldName}
                   max={max}
                   min={min}
                   maxLength={maxLength}
@@ -121,36 +123,39 @@ const FormInput = (props: RadixFormInputProps) => {
           }}
         </Form.ValidityState>
         <FormInputMessage
-          title={createValueMissingMessage(name)}
+          title={createValueMissingMessage(fieldName)}
           match="valueMissing"
         />
         <FormInputMessage
-          title={createInvalidMessage(name)}
+          title={createInvalidMessage(fieldName)}
           match="typeMismatch"
         />
-        <FormInputMessage title={createInvalidMessage(name)} match="badInput" />
         <FormInputMessage
-          title={createInvalidMessage(name)}
+          title={createInvalidMessage(fieldName)}
+          match="badInput"
+        />
+        <FormInputMessage
+          title={createInvalidMessage(fieldName)}
           match="patternMismatch"
         />
         <FormInputMessage
-          title={createTooHighMessage(name, max)}
+          title={createTooHighMessage(fieldName, max)}
           match="rangeOverflow"
         />
         <FormInputMessage
-          title={createTooLowMessage(name, min)}
+          title={createTooLowMessage(fieldName, min)}
           match="rangeUnderflow"
         />
         <FormInputMessage
-          title={createInvalidMessage(name)}
+          title={createInvalidMessage(fieldName)}
           match="stepMismatch"
         />
         <FormInputMessage
-          title={createTooLongMessage(name, maxLength)}
+          title={createTooLongMessage(fieldName, maxLength)}
           match="tooLong"
         />
         <FormInputMessage
-          title={createTooShortMessage(name, minLength)}
+          title={createTooShortMessage(fieldName, minLength)}
           match="tooShort"
         />
         {validators.map((validator, index) => (

--- a/frontend/src/components/shared/form/sub/FormSubmit.tsx
+++ b/frontend/src/components/shared/form/sub/FormSubmit.tsx
@@ -1,4 +1,4 @@
-import { Button, Flex } from '@radix-ui/themes';
+import { Button, ButtonProps, Flex } from '@radix-ui/themes';
 import { Form as RadixForm } from 'radix-ui';
 import LoadingSpinner from '../../LoadingSpinner.tsx';
 import { MarginProps } from '@radix-ui/themes/props';
@@ -8,21 +8,25 @@ interface FormSubmitProps extends MarginProps {
   title: string;
   isServerPending?: boolean;
   icon?: IconType;
+  color?: ButtonProps['color'];
+  width?: string;
 }
 
 const FormSubmit = ({
   isServerPending,
   title,
   icon: Icon,
+  color,
+  width = '100%',
   ...props
 }: FormSubmitProps) => {
   const { ...marginProps } = props;
 
   return (
-    <Flex justify="center" align="center" width="100%" my="3" {...marginProps}>
+    <Flex justify="center" align="center" width={width} my="3" {...marginProps}>
       <LoadingSpinner size="small" isLoading={isServerPending}>
         <RadixForm.Submit asChild>
-          <Button size="4" className="!w-full">
+          <Button size="4" color={color} className="!w-full">
             {title}
             {Icon && (
               <Icon

--- a/frontend/src/utils/reactChildren.ts
+++ b/frontend/src/utils/reactChildren.ts
@@ -1,0 +1,46 @@
+import { Children, isValidElement, ReactElement, ReactNode } from 'react';
+
+export const hasChildren = (
+  element: ReactNode
+): element is ReactElement<{ children: ReactNode | ReactNode[] }> =>
+  isValidElement<{ children?: ReactNode[] }>(element) &&
+  Boolean(element.props.children);
+
+export const childToString = (child: ReactNode): string => {
+  if (
+    typeof child === 'undefined' ||
+    child === null ||
+    typeof child === 'boolean'
+  ) {
+    return '';
+  }
+
+  if (JSON.stringify(child) === '{}') {
+    return '';
+  }
+
+  // Disabled eslint since we know we can expect string representation of the child
+  // eslint-disable-next-line @typescript-eslint/no-base-to-string
+  return child.toString();
+};
+
+export const textContent = (children: ReactNode | ReactNode[]): string => {
+  if (!(children instanceof Array) && !isValidElement(children)) {
+    return childToString(children);
+  }
+
+  return Children.toArray(children).reduce(
+    (text: string, child: ReactNode): string => {
+      let newText = '';
+
+      if (hasChildren(child)) {
+        newText = textContent(child.props.children);
+      } else if (!isValidElement(child)) {
+        newText = childToString(child);
+      }
+
+      return text.concat(newText);
+    },
+    ''
+  );
+};

--- a/frontend/tests/components/profile/Profile.test.tsx
+++ b/frontend/tests/components/profile/Profile.test.tsx
@@ -2,7 +2,7 @@ import * as profileApiModule from '../../../src/store/api/profile.ts';
 import { afterEach, beforeEach, expect } from 'vitest';
 import { ProfileType } from '../../../src/types/api/ProfileTypes.ts';
 import { renderWithProviders } from '../../test-utils.tsx';
-import { screen } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 import Profile from '../../../src/components/profile/Profile.tsx';
 
 const profileData: ProfileType = {
@@ -82,5 +82,80 @@ describe('Profile', () => {
 
     // Then
     expect(emailElement).toBeInTheDocument();
+  });
+
+  describe('Editability', () => {
+    const editButton = 'Edit profile';
+
+    it('Should contain Edit profile button', () => {
+      // Given
+      renderWithProviders(<Profile />);
+
+      // When
+      const editButtonElement = screen.getByRole('button', {
+        name: editButton,
+      });
+
+      // Then
+      expect(editButtonElement).toBeInTheDocument();
+    });
+
+    it('Should start editing profile, when edit clicked', () => {
+      // Given
+      renderWithProviders(<Profile />);
+      const editButtonElement = screen.getByRole('button', {
+        name: editButton,
+      });
+
+      // When
+      fireEvent.click(editButtonElement);
+      const textboxElements = screen.getAllByRole('textbox');
+
+      // Then
+      expect(textboxElements.length).toBeGreaterThan(0);
+      textboxElements.forEach((textbox) => {
+        expect(textbox).toBeInTheDocument();
+      });
+    });
+
+    it('Should contain Update and Cancel buttons', () => {
+      // Given
+      renderWithProviders(<Profile />);
+      const editButtonElement = screen.getByRole('button', {
+        name: editButton,
+      });
+
+      // When
+      fireEvent.click(editButtonElement);
+      const updateButtonElement = screen.getByRole('button', {
+        name: 'Save changes',
+      });
+      const cancelButtonElement = screen.getByRole('button', {
+        name: 'Cancel',
+      });
+
+      // Then
+      expect(updateButtonElement).toBeInTheDocument();
+      expect(cancelButtonElement).toBeInTheDocument();
+    });
+
+    it('Should stop editing profile, when cancel clicked', () => {
+      // Given
+      renderWithProviders(<Profile />);
+      const editButtonElement = screen.getByRole('button', {
+        name: editButton,
+      });
+      fireEvent.click(editButtonElement);
+
+      // When
+      const cancelButtonElement = screen.getByRole('button', {
+        name: 'Cancel',
+      });
+      fireEvent.click(cancelButtonElement);
+      const textboxElements = screen.queryAllByRole('textbox');
+
+      // then
+      expect(textboxElements).toHaveLength(0);
+    });
   });
 });

--- a/frontend/tests/components/profile/ProfileControls.test.tsx
+++ b/frontend/tests/components/profile/ProfileControls.test.tsx
@@ -1,0 +1,112 @@
+import ProfileControls from '../../../src/components/profile/ProfileControls.tsx';
+import { Form } from 'radix-ui';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach } from 'vitest';
+import { FormEvent, PropsWithChildren } from 'react';
+
+const TestWrapper = ({ children }: PropsWithChildren) => {
+  return (
+    <Form.Root
+      onSubmit={vi
+        .fn()
+        .mockImplementation((event: FormEvent<HTMLFormElement>) => {
+          event.preventDefault();
+        })}
+    >
+      {children}
+    </Form.Root>
+  );
+};
+
+describe('ProfileControls', () => {
+  const mockHandleEdit = vi.fn();
+  const mockHandleCancel = vi.fn();
+
+  const editTitle = 'Edit profile';
+  const saveChangesTitle = 'Save changes';
+  const cancelTitle = 'Cancel';
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('Should contain edit button, when not editing', () => {
+    // Given
+    const isEditing = false;
+    render(
+      <ProfileControls
+        isEdited={isEditing}
+        onEdit={mockHandleEdit}
+        onCancel={mockHandleCancel}
+      />,
+      { wrapper: TestWrapper }
+    );
+
+    // When
+    const editButton = screen.getByRole('button', { name: editTitle });
+
+    // Then
+    expect(editButton).toBeInTheDocument();
+  });
+
+  it('Should contain save and cancel buttons, when editing', () => {
+    // Given
+    const isEditing = true;
+    render(
+      <ProfileControls
+        isEdited={isEditing}
+        onEdit={mockHandleEdit}
+        onCancel={mockHandleCancel}
+      />,
+      { wrapper: TestWrapper }
+    );
+
+    // When
+    const saveButton = screen.getByRole('button', { name: saveChangesTitle });
+    const cancelButton = screen.getByRole('button', { name: cancelTitle });
+
+    // Then
+    expect(saveButton).toBeInTheDocument();
+    expect(cancelButton).toBeInTheDocument();
+  });
+
+  it('Should call handleEdit on edit button click', () => {
+    // Given
+    const isEditing = false;
+    render(
+      <ProfileControls
+        isEdited={isEditing}
+        onEdit={mockHandleEdit}
+        onCancel={mockHandleCancel}
+      />,
+      { wrapper: TestWrapper }
+    );
+    const editButton = screen.getByRole('button', { name: editTitle });
+
+    // When
+    fireEvent.click(editButton);
+
+    // Then
+    expect(mockHandleEdit).toHaveBeenCalledOnce();
+  });
+
+  it('Should call handleCancel on cancel button click', () => {
+    // Given
+    const isEditing = true;
+    render(
+      <ProfileControls
+        isEdited={isEditing}
+        onEdit={mockHandleEdit}
+        onCancel={mockHandleCancel}
+      />,
+      { wrapper: TestWrapper }
+    );
+    const cancelButton = screen.getByRole('button', { name: cancelTitle });
+
+    // When
+    fireEvent.click(cancelButton);
+
+    // Then
+    expect(mockHandleCancel).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/tests/components/profile/ProfileItem.test.tsx
+++ b/frontend/tests/components/profile/ProfileItem.test.tsx
@@ -1,14 +1,30 @@
 import { render, screen } from '@testing-library/react';
 import ProfileItem from '../../../src/components/profile/ProfileItem.tsx';
 import { DataList } from '@radix-ui/themes';
+import { FormEvent, PropsWithChildren } from 'react';
+import { Form } from 'radix-ui';
+
+const TestWrapper = ({ children }: PropsWithChildren) => {
+  return (
+    <Form.Root
+      onSubmit={vi
+        .fn()
+        .mockImplementation((event: FormEvent<HTMLFormElement>) => {
+          event.preventDefault();
+        })}
+    >
+      <DataList.Root>{children}</DataList.Root>
+    </Form.Root>
+  );
+};
 
 describe('ProfileItem', () => {
   describe('Title', () => {
     it('Should render title', () => {
       // Given
       const title = 'Test Title';
-      render(<ProfileItem isLoading={false} title={title} />, {
-        wrapper: DataList.Root,
+      render(<ProfileItem isLoading={false} isEdited={false} title={title} />, {
+        wrapper: TestWrapper,
       });
 
       // When
@@ -20,8 +36,8 @@ describe('ProfileItem', () => {
 
     it('Should not render title when not provided', () => {
       // Given
-      render(<ProfileItem isLoading={false} />, {
-        wrapper: DataList.Root,
+      render(<ProfileItem isLoading={false} isEdited={false} />, {
+        wrapper: TestWrapper,
       });
 
       // When
@@ -37,9 +53,14 @@ describe('ProfileItem', () => {
 
     it('Should render children', () => {
       // Given
-      render(<ProfileItem isLoading={false}>{children}</ProfileItem>, {
-        wrapper: DataList.Root,
-      });
+      render(
+        <ProfileItem isLoading={false} isEdited={false}>
+          {children}
+        </ProfileItem>,
+        {
+          wrapper: TestWrapper,
+        }
+      );
 
       // When
       const childrenElement = screen.getByText(children);
@@ -50,15 +71,56 @@ describe('ProfileItem', () => {
 
     it('Should render skeleton when loading', () => {
       // Given
-      render(<ProfileItem isLoading={true}>{children}</ProfileItem>, {
-        wrapper: DataList.Root,
-      });
+      render(
+        <ProfileItem isLoading={true} isEdited={false}>
+          {children}
+        </ProfileItem>,
+        {
+          wrapper: TestWrapper,
+        }
+      );
 
       // When
       const childrenElement = screen.queryByRole('definition');
 
       // Then
       expect(childrenElement).not.toBeInTheDocument();
+    });
+
+    it('Should render textbox when editing', () => {
+      // Given
+      render(
+        <ProfileItem isLoading={true} isEdited={true}>
+          {children}
+        </ProfileItem>,
+        {
+          wrapper: TestWrapper,
+        }
+      );
+
+      // When
+      const textboxElement = screen.getByRole('textbox');
+
+      // Then
+      expect(textboxElement).toBeInTheDocument();
+    });
+
+    it('Should inject value to textbox when editing', () => {
+      // Given
+      render(
+        <ProfileItem isLoading={true} isEdited={true}>
+          {children}
+        </ProfileItem>,
+        {
+          wrapper: TestWrapper,
+        }
+      );
+
+      // When
+      const textboxElement = screen.getByRole('textbox');
+
+      // Then
+      expect(textboxElement).toHaveValue(children);
     });
   });
 });

--- a/frontend/tests/components/shared/form/sub/FormInput.test.tsx
+++ b/frontend/tests/components/shared/form/sub/FormInput.test.tsx
@@ -7,15 +7,46 @@ import { afterEach, beforeEach } from 'vitest';
 describe('FormInput', () => {
   const label = 'Test label';
 
-  it('Should render label', () => {
-    // Given
+  describe('Label', () => {
+    it('Should render label', () => {
+      // Given
 
-    // When
-    render(<FormInput name={label} />, { wrapper: Form.Root });
-    const labelElement = screen.getByText(label);
+      // When
+      render(<FormInput name={label} />, { wrapper: Form.Root });
+      const labelElement = screen.getByText(label);
+      const textboxElement = screen.getByRole('textbox');
 
-    // Then
-    expect(labelElement).toBeInTheDocument();
+      // Then
+      expect(labelElement).toBeInTheDocument();
+      expect(textboxElement).toHaveAttribute('name', label);
+    });
+
+    it('Should not render label and name as id', () => {
+      // Given
+
+      // When
+      render(<FormInput id={label} />, { wrapper: Form.Root });
+      const labelElement = screen.queryByText(label);
+      const textboxElement = screen.getByRole('textbox');
+
+      // Then
+      expect(labelElement).not.toBeInTheDocument();
+      expect(textboxElement).toHaveAttribute('name', label);
+    });
+
+    it('Should not render label and default name', () => {
+      // Given
+      const defaultField = 'field';
+
+      // When
+      render(<FormInput />, { wrapper: Form.Root });
+      const labelElement = screen.queryByText(defaultField);
+      const textboxElement = screen.getByRole('textbox');
+
+      // Then
+      expect(labelElement).not.toBeInTheDocument();
+      expect(textboxElement).toHaveAttribute('name', defaultField);
+    });
   });
 
   describe('Render input elements', () => {

--- a/frontend/tests/utils/reactChildren.test.tsx
+++ b/frontend/tests/utils/reactChildren.test.tsx
@@ -1,0 +1,336 @@
+import {
+  childToString,
+  hasChildren,
+  textContent,
+} from '../../src/utils/reactChildren.ts';
+import { ReactNode } from 'react';
+
+describe('reactChildren', () => {
+  describe('hasChildren', () => {
+    it('Should return true, when has children', () => {
+      // Given
+      const element = (
+        <div>
+          <div />
+          <div />
+        </div>
+      );
+
+      // When
+      const result = hasChildren(element);
+
+      // Then
+      expect(result).toBe(true);
+    });
+
+    it('Should return true, when has string', () => {
+      // Given
+      const element = <div>Text</div>;
+
+      // When
+      const result = hasChildren(element);
+
+      // Then
+      expect(result).toBe(true);
+    });
+
+    it('Should return true, when has number', () => {
+      // Given
+      const element = <div>{3}</div>;
+
+      // When
+      const result = hasChildren(element);
+
+      // Then
+      expect(result).toBe(true);
+    });
+
+    it('Should return true, when has boolean', () => {
+      // Given
+      const element = <div>{true}</div>;
+
+      // When
+      const result = hasChildren(element);
+
+      // Then
+      expect(result).toBe(true);
+    });
+
+    it('Should return true, when has combined', () => {
+      // Given
+      const element = (
+        <div>
+          Text
+          {true}
+          <div />
+        </div>
+      );
+
+      // When
+      const result = hasChildren(element);
+
+      // Then
+      expect(result).toBe(true);
+    });
+
+    it('Should return true, when combined with null', () => {
+      // Given
+      const element = (
+        <div>
+          Text
+          {true}
+          {null}
+          <div />
+        </div>
+      );
+
+      // When
+      const result = hasChildren(element);
+
+      // Then
+      expect(result).toBe(true);
+    });
+
+    it('Should return false, when empty', () => {
+      // Given
+      const element = <div />;
+
+      // When
+      const result = hasChildren(element);
+
+      // Then
+      expect(result).toBe(false);
+    });
+
+    it('Should return false, when null', () => {
+      // Given
+      const element = <div>{null}</div>;
+
+      // When
+      const result = hasChildren(element);
+
+      // Then
+      expect(result).toBe(false);
+    });
+
+    it('Should return false, when false', () => {
+      // Given
+      const element = <div>{false}</div>;
+
+      // When
+      const result = hasChildren(element);
+
+      // Then
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('childToString', () => {
+    it('Should return string, when string', () => {
+      // Given
+      const child = 'text';
+
+      // When
+      const result = childToString(child);
+
+      // Then
+      expect(result).toEqual(child);
+    });
+
+    it('Should return string, when number', () => {
+      // Given
+      const child = 2;
+
+      // When
+      const result = childToString(child);
+
+      // Then
+      expect(result).toEqual(child.toString());
+    });
+
+    it('Should return empty, when boolean', () => {
+      // Given
+      const child = true;
+
+      // When
+      const result = childToString(child);
+
+      // Then
+      expect(result).toEqual('');
+    });
+
+    it('Should return empty, when empty object', () => {
+      // Given
+      const child = {};
+
+      // When
+      const result = childToString(child as ReactNode);
+
+      // Then
+      expect(result).toEqual('');
+    });
+
+    it('Should return empty, when null', () => {
+      // Given
+      const child = null;
+
+      // When
+      const result = childToString(child);
+
+      // Then
+      expect(result).toEqual('');
+    });
+
+    it('Should return empty, when undefined', () => {
+      // Given
+      const child = undefined;
+
+      // When
+      const result = childToString(child);
+
+      // Then
+      expect(result).toEqual('');
+    });
+  });
+
+  describe('textContent', () => {
+    it('Should return correctly on text', () => {
+      // Given
+      const value = 'Text';
+      const element = <div>{value}</div>;
+
+      // When
+      const result = textContent(element);
+
+      // Then
+      expect(result).toEqual(value);
+    });
+
+    it('Should return correctly on number', () => {
+      // Given
+      const value = 2;
+      const element = <div>{value}</div>;
+
+      // When
+      const result = textContent(element);
+
+      // Then
+      expect(result).toEqual(value.toString());
+    });
+
+    it('Should return correctly on boolean', () => {
+      // Given
+      const valueTrue = true;
+      const valueFalse = false;
+      const elementTrue = <div>{valueTrue}</div>;
+      const elementFalse = <div>{valueFalse}</div>;
+
+      // When
+      const resultTrue = textContent(elementTrue);
+      const resultFalse = textContent(elementFalse);
+
+      // Then
+      expect(resultTrue).toEqual('');
+      expect(resultFalse).toEqual('');
+    });
+
+    it('Should return correctly on null', () => {
+      // Given
+      const value = null;
+      const element = <div>{value}</div>;
+
+      // When
+      const result = textContent(element);
+
+      // Then
+      expect(result).toEqual('');
+    });
+
+    it('Should return correctly on combined types', () => {
+      // Given
+      const valueString = 'Text';
+      const valueNumber = 2;
+      const valueBoolean = true;
+      const valueNull = null;
+      const element = (
+        <div>
+          {valueString}
+          {valueNumber}
+          {valueBoolean}
+          {valueNull}
+        </div>
+      );
+
+      // When
+      const result = textContent(element);
+
+      // Then
+      expect(result).toEqual(valueString + valueNumber.toString());
+    });
+
+    it('Should return correctly on non nested objects', () => {
+      // Given
+      const valueString = 'Text';
+      const valueNumber = 2;
+      const element = (
+        <>
+          <div>{valueString}</div>
+          <div>{valueNumber}</div>
+        </>
+      );
+
+      // When
+      const result = textContent(element);
+
+      // Then
+      expect(result).toEqual(valueString + valueNumber.toString());
+    });
+
+    it('Should return correctly on nested objects', () => {
+      // Given
+      const valueString = 'Text';
+      const valueNumber = 2;
+      const element = (
+        <>
+          <div>{valueString}</div>
+          <div>
+            {valueNumber}
+            <div>Nested</div>
+          </div>
+        </>
+      );
+
+      // When
+      const result = textContent(element);
+
+      // Then
+      expect(result).toEqual(valueString + valueNumber.toString() + 'Nested');
+    });
+
+    it('Should return correctly on empty', () => {
+      // Given
+      const element = <div />;
+
+      // When
+      const result = textContent(element);
+
+      // Then
+      expect(result).toEqual('');
+    });
+
+    it('Should return correctly on empty children', () => {
+      // Given
+      const element = (
+        <div>
+          <div />
+        </div>
+      );
+
+      // When
+      const result = textContent(element);
+
+      // Then
+      expect(result).toEqual('');
+    });
+  });
+});


### PR DESCRIPTION
Added editability option to profile page. On profile page now new buttons are added - Edit, Update and Cancel. Two latter are only shown in editable state, which is after clicking Edit button.

All fields except email are morthign to text field to allow for changes of the elements. Email cannot be changed since this is also a login.