### PR TITLE
[BE] Add profile.update message receiver in Profile Service

### DIFF
--- a/backend/profile-service/src/main/java/org/maxq/profileservice/controller/QaController.java
+++ b/backend/profile-service/src/main/java/org/maxq/profileservice/controller/QaController.java
@@ -23,7 +23,7 @@ public class QaController implements QaApi {
   @Override
   @PostMapping("/profiles")
   public ResponseEntity<ProfileDto> createProfile(@RequestBody ProfileDto profileDto) {
-    createProfileMessageReceiver.receiveCreateMessage(profileDto);
+    createProfileMessageReceiver.receiveUpdateMessage(profileDto);
     return ResponseEntity.status(HttpStatus.CREATED).body(profileDto);
   }
 }

--- a/backend/profile-service/src/main/java/org/maxq/profileservice/controller/api/ProfileApi.java
+++ b/backend/profile-service/src/main/java/org/maxq/profileservice/controller/api/ProfileApi.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.maxq.profileservice.domain.HttpErrorMessage;
 import org.maxq.profileservice.domain.dto.ProfileDto;
+import org.maxq.profileservice.domain.dto.UpdateProfileDto;
 import org.maxq.profileservice.domain.exception.ElementNotFoundException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -54,8 +55,7 @@ public interface ProfileApi {
           @Content(mediaType = "application/json", schema = @Schema(implementation = HttpErrorMessage.class))
       })
   @ApiResponse(responseCode = "403",
-      description = "Unauthorized - only logged in users can access this resource, or tried to " +
-          "access profile of other user",
+      description = "Unauthorized - only logged in users can access this resource",
       content = {
           @Content(mediaType = "application/json", schema = @Schema(implementation = HttpErrorMessage.class))
       })
@@ -64,6 +64,6 @@ public interface ProfileApi {
       content = {
           @Content(mediaType = "application/json", schema = @Schema(implementation = HttpErrorMessage.class))
       })
-  ResponseEntity<Void> updateProfile(Authentication authentication, ProfileDto profileDto)
+  ResponseEntity<Void> updateProfile(Authentication authentication, UpdateProfileDto profileDto)
       throws ElementNotFoundException;
 }

--- a/backend/profile-service/src/main/java/org/maxq/profileservice/domain/dto/ProfileDto.java
+++ b/backend/profile-service/src/main/java/org/maxq/profileservice/domain/dto/ProfileDto.java
@@ -16,4 +16,11 @@ public class ProfileDto {
   private String firstName;
   private String middleName;
   private String lastName;
+
+  public ProfileDto(String email, String firstName, String middleName, String lastName) {
+    this.email = email;
+    this.firstName = firstName;
+    this.middleName = middleName;
+    this.lastName = lastName;
+  }
 }

--- a/backend/profile-service/src/main/java/org/maxq/profileservice/domain/dto/UpdateProfileDto.java
+++ b/backend/profile-service/src/main/java/org/maxq/profileservice/domain/dto/UpdateProfileDto.java
@@ -1,0 +1,18 @@
+package org.maxq.profileservice.domain.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class UpdateProfileDto {
+
+  @NotNull
+  private String firstName;
+  private String middleName;
+  @NotNull
+  private String lastName;
+}

--- a/backend/profile-service/src/main/java/org/maxq/profileservice/service/ProfileService.java
+++ b/backend/profile-service/src/main/java/org/maxq/profileservice/service/ProfileService.java
@@ -1,6 +1,7 @@
 package org.maxq.profileservice.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.maxq.profileservice.domain.Profile;
 import org.maxq.profileservice.domain.exception.DataValidationException;
 import org.maxq.profileservice.domain.exception.DuplicateEmailException;
@@ -10,6 +11,7 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.TransactionSystemException;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ProfileService {
@@ -31,6 +33,23 @@ public class ProfileService {
     } catch (DataIntegrityViolationException e) {
       throw new DuplicateEmailException(
           "User with this email already exists! Email: " + profile.getEmail(), e);
+    }
+  }
+
+  public void updateProfile(Profile profile) throws DataValidationException {
+    Profile profileToSave;
+    try {
+      Profile foundProfile = this.getProfileByEmail(profile.getEmail());
+      profileToSave = new Profile(foundProfile.getId(), profile.getEmail(), profile.getFirstName(), profile.getMiddleName(), profile.getLastName());
+    } catch (ElementNotFoundException e) {
+      log.warn("Profile not found when updating, creating new profile: {}", profile.getEmail(), e);
+      profileToSave = new Profile(profile.getEmail(), profile.getFirstName(), profile.getMiddleName(), profile.getLastName());
+    }
+
+    try {
+      profileRepository.save(profileToSave);
+    } catch (TransactionSystemException e) {
+      throw new DataValidationException("Failed email or password validation", e);
     }
   }
 

--- a/backend/profile-service/src/main/java/org/maxq/profileservice/service/message/handler/UpdateProfileHandler.java
+++ b/backend/profile-service/src/main/java/org/maxq/profileservice/service/message/handler/UpdateProfileHandler.java
@@ -1,0 +1,31 @@
+package org.maxq.profileservice.service.message.handler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.maxq.profileservice.domain.Profile;
+import org.maxq.profileservice.domain.dto.ProfileDto;
+import org.maxq.profileservice.domain.exception.DataValidationException;
+import org.maxq.profileservice.mapper.ProfileMapper;
+import org.maxq.profileservice.service.ProfileService;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UpdateProfileHandler implements MessageHandler<ProfileDto> {
+
+  private final ProfileService profileService;
+  private final ProfileMapper profileMapper;
+
+  @Override
+  public void handleMessage(ProfileDto message) {
+    log.info("Handling message with profile: {}", message);
+    Profile profile = profileMapper.mapToProfile(message);
+    try {
+      profileService.updateProfile(profile);
+      log.info("Profile update handled: {}", profile);
+    } catch (DataValidationException e) {
+      log.error("Failed to handle profile profile: {}", profile, e);
+    }
+  }
+}

--- a/backend/profile-service/src/main/java/org/maxq/profileservice/service/message/listener/UpdateProfileMessageReceiver.java
+++ b/backend/profile-service/src/main/java/org/maxq/profileservice/service/message/listener/UpdateProfileMessageReceiver.java
@@ -3,25 +3,25 @@ package org.maxq.profileservice.service.message.listener;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.maxq.profileservice.domain.dto.ProfileDto;
-import org.maxq.profileservice.service.message.handler.CreateProfileHandler;
+import org.maxq.profileservice.service.message.handler.UpdateProfileHandler;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class CreateProfileMessageReceiver implements MessageReceiver<ProfileDto> {
+public class UpdateProfileMessageReceiver implements MessageReceiver<ProfileDto> {
 
-  private final CreateProfileHandler createProfileHandler;
+  private final UpdateProfileHandler updateProfileHandler;
 
-  @RabbitListener(id = "createProfileReceiver", queues = "${profile.queue.create}")
-  public void receiveUpdateMessage(ProfileDto profile) {
+  @RabbitListener(id = "updateProfileReceiver", queues = "${profile.queue.update}")
+  public void receiveCreateMessage(ProfileDto profile) {
     receiveMessage(profile);
   }
 
   @Override
   public void receiveMessage(ProfileDto profile) {
     log.info("Received message: {}", profile);
-    createProfileHandler.handleMessage(profile);
+    updateProfileHandler.handleMessage(profile);
   }
 }

--- a/backend/profile-service/src/test/java/org/maxq/profileservice/controller/ProfileControllerTest.java
+++ b/backend/profile-service/src/test/java/org/maxq/profileservice/controller/ProfileControllerTest.java
@@ -161,7 +161,7 @@ class ProfileControllerTest {
 
     // When + Then
     mockMvc.perform(MockMvcRequestBuilders
-            .put(URL)
+            .put(URL + "/me")
             .contentType(MediaType.APPLICATION_JSON)
             .content(GSON.toJson(updatedProfile))
             .header(HttpHeaders.AUTHORIZATION, "Bearer test-token")
@@ -184,7 +184,7 @@ class ProfileControllerTest {
 
     // When + Then
     mockMvc.perform(MockMvcRequestBuilders
-            .put(URL)
+            .put(URL + "/me")
             .contentType(MediaType.APPLICATION_JSON)
             .content(GSON.toJson(updatedProfile))
             .header("X-User", email)
@@ -204,30 +204,9 @@ class ProfileControllerTest {
 
     // When + Then
     mockMvc.perform(MockMvcRequestBuilders
-            .put(URL)
+            .put(URL + "/me")
             .contentType(MediaType.APPLICATION_JSON)
             .content(GSON.toJson(updatedProfile))
-            .header(HttpHeaders.AUTHORIZATION, "Bearer test-token"))
-        .andExpect(MockMvcResultMatchers.status().isForbidden())
-        .andExpect(MockMvcResultMatchers
-            .jsonPath("$.message", Matchers.is("Forbidden: You don't have permission to access this resource")));
-  }
-
-  @Test
-  void shouldThrow403_When_UserNotMatchUpdate() throws Exception {
-    // Given
-    when(profileService.getProfileByEmail(email)).thenReturn(profile);
-    ProfileDto updatedProfile = new ProfileDto(
-        profileDto.getId(), profileDto.getEmail(),
-        "UpdatedName", null, "UpdatedLastName");
-
-    // When + Then
-    mockMvc.perform(MockMvcRequestBuilders
-            .put(URL)
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(GSON.toJson(updatedProfile))
-            .header("X-User", "other@email.com")
-            .header("X-User-Roles", roles)
             .header(HttpHeaders.AUTHORIZATION, "Bearer test-token"))
         .andExpect(MockMvcResultMatchers.status().isForbidden())
         .andExpect(MockMvcResultMatchers

--- a/backend/profile-service/src/test/java/org/maxq/profileservice/repository/ProfileRepositoryTest.java
+++ b/backend/profile-service/src/test/java/org/maxq/profileservice/repository/ProfileRepositoryTest.java
@@ -93,6 +93,33 @@ class ProfileRepositoryTest {
   }
 
   @Test
+  void shouldUpdateProfile() {
+    // Given
+    profileRepository.save(profile);
+    Profile updatedProfile = new Profile(
+        profile.getId(), profile.getEmail(),
+        "UpdatedName", "UpdatedMiddleName", "UpdatedLastName"
+    );
+
+    // When
+    profileRepository.save(updatedProfile);
+    Optional<Profile> foundProfile = profileRepository.findById(profile.getId());
+
+    // Then
+    assertTrue(foundProfile.isPresent(), "Profile should be found after update");
+    assertAll(
+        () -> assertEquals(updatedProfile.getEmail(), foundProfile.get().getEmail(),
+            "Profile should save with equal email"),
+        () -> assertEquals(updatedProfile.getFirstName(), foundProfile.get().getFirstName(),
+            "Profile should save with equal first name"),
+        () -> assertEquals(updatedProfile.getMiddleName(), foundProfile.get().getMiddleName(),
+            "Middle name should be null"),
+        () -> assertEquals(updatedProfile.getLastName(), foundProfile.get().getLastName(),
+            "Profile should save with equal last name")
+    );
+  }
+
+  @Test
   void shouldFindByEmail() {
     // Given
     profileRepository.save(profile);

--- a/backend/profile-service/src/test/java/org/maxq/profileservice/service/message/handler/UpdateProfileHandlerTest.java
+++ b/backend/profile-service/src/test/java/org/maxq/profileservice/service/message/handler/UpdateProfileHandlerTest.java
@@ -1,0 +1,69 @@
+package org.maxq.profileservice.service.message.handler;
+
+import org.junit.jupiter.api.Test;
+import org.maxq.profileservice.domain.Profile;
+import org.maxq.profileservice.domain.dto.ProfileDto;
+import org.maxq.profileservice.domain.exception.DataValidationException;
+import org.maxq.profileservice.mapper.ProfileMapper;
+import org.maxq.profileservice.service.ProfileService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+class UpdateProfileHandlerTest {
+
+  @Autowired
+  private UpdateProfileHandler handler;
+
+  @MockitoBean
+  private ProfileService profileService;
+  @MockitoBean
+  private ProfileMapper profileMapper;
+
+  @Test
+  void shouldHandleMessage() throws DataValidationException {
+    // Given
+    ProfileDto profileDto
+        = new ProfileDto(null, "test@test.com", "UpdateName", "UpdateMiddleName", "UpdateLastName");
+    Profile profile = new Profile(
+        profileDto.getId(),
+        profileDto.getEmail(), profileDto.getFirstName(),
+        profileDto.getMiddleName(), profileDto.getLastName()
+    );
+    when(profileMapper.mapToProfile(profileDto)).thenReturn(profile);
+
+    // When
+    handler.handleMessage(profileDto);
+
+    // Then
+    verify(profileService, times(1))
+        .updateProfile(argThat(profileCall ->
+            profileCall.getId() == null
+                && profile.getEmail().equals(profileCall.getEmail())
+                && profile.getFirstName().equals(profileCall.getFirstName())
+                && profile.getMiddleName().equals(profileCall.getMiddleName())
+                && profile.getLastName().equals(profileCall.getLastName())
+        ));
+  }
+
+  @Test
+  void shouldNotThrow_When_UpdateThrows() throws DataValidationException {
+    // Given
+    ProfileDto profileDto
+        = new ProfileDto(null, "test@test.com", "UpdateName", "UpdateMiddleName", "UpdateLastName");
+    Profile profile = new Profile(
+        profileDto.getId(),
+        profileDto.getEmail(), profileDto.getFirstName(),
+        profileDto.getMiddleName(), profileDto.getLastName()
+    );
+    when(profileMapper.mapToProfile(profileDto)).thenReturn(profile);
+    doThrow(DataValidationException.class).when(profileService).updateProfile(any(Profile.class));
+
+    // When + Then
+    assertDoesNotThrow(() -> handler.handleMessage(profileDto));
+  }
+}

--- a/backend/profile-service/src/test/java/org/maxq/profileservice/service/message/listener/CreateProfileMessageReceiverTest.java
+++ b/backend/profile-service/src/test/java/org/maxq/profileservice/service/message/listener/CreateProfileMessageReceiverTest.java
@@ -25,7 +25,7 @@ class CreateProfileMessageReceiverTest {
     ProfileDto profileDto = new ProfileDto(1L, "test@test.com", "Test", null, "User");
 
     // When
-    messageReceiver.receiveCreateMessage(profileDto);
+    messageReceiver.receiveUpdateMessage(profileDto);
 
     // Then
     verify(createProfileHandler, times(1)).handleMessage(profileDto);

--- a/backend/profile-service/src/test/java/org/maxq/profileservice/service/message/listener/UpdateProfileMessageReceiverTest.java
+++ b/backend/profile-service/src/test/java/org/maxq/profileservice/service/message/listener/UpdateProfileMessageReceiverTest.java
@@ -1,0 +1,41 @@
+package org.maxq.profileservice.service.message.listener;
+
+import org.junit.jupiter.api.Test;
+import org.maxq.profileservice.domain.dto.ProfileDto;
+import org.maxq.profileservice.service.message.handler.UpdateProfileHandler;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@SpringBootTest
+class UpdateProfileMessageReceiverTest {
+
+  @Autowired
+  private UpdateProfileMessageReceiver messageReceiver;
+
+  @MockitoBean
+  private UpdateProfileHandler updateProfileHandler;
+
+  @Test
+  void shouldReceiveCreateMessage() {
+    // Give
+    ProfileDto profileDto
+        = new ProfileDto(null, "test@test.com", "UpdateName", "UpdateMiddleName", "UpdateLastName");
+
+    // When
+    messageReceiver.receiveCreateMessage(profileDto);
+
+    // Then
+    verify(updateProfileHandler, times(1))
+        .handleMessage(argThat(profile ->
+            profileDto.getEmail().equals(profile.getEmail())
+                && profileDto.getFirstName().equals(profile.getFirstName())
+                && profileDto.getMiddleName().equals(profile.getMiddleName())
+                && profileDto.getLastName().equals(profile.getLastName())
+        ));
+  }
+}


### PR DESCRIPTION
Create listener for profile update message, that process update message and if a profile does not exist new profile will be created.

Also updated ProfileController to not require email in request, but infer email from logged in authentication principal.