### PR TITLE
[BE] add QA endpoint to PUT /qa/profiles

### DIFF
--- a/backend/profile-service/src/main/java/org/maxq/profileservice/controller/QaController.java
+++ b/backend/profile-service/src/main/java/org/maxq/profileservice/controller/QaController.java
@@ -4,13 +4,11 @@ import lombok.RequiredArgsConstructor;
 import org.maxq.profileservice.controller.api.QaApi;
 import org.maxq.profileservice.domain.dto.ProfileDto;
 import org.maxq.profileservice.service.message.listener.CreateProfileMessageReceiver;
+import org.maxq.profileservice.service.message.listener.UpdateProfileMessageReceiver;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/qa")
@@ -19,11 +17,19 @@ import org.springframework.web.bind.annotation.RestController;
 public class QaController implements QaApi {
 
   private final CreateProfileMessageReceiver createProfileMessageReceiver;
+  private final UpdateProfileMessageReceiver updateProfileMessageReceiver;
 
   @Override
   @PostMapping("/profiles")
   public ResponseEntity<ProfileDto> createProfile(@RequestBody ProfileDto profileDto) {
     createProfileMessageReceiver.receiveUpdateMessage(profileDto);
     return ResponseEntity.status(HttpStatus.CREATED).body(profileDto);
+  }
+
+  @Override
+  @PutMapping("/profiles")
+  public ResponseEntity<ProfileDto> updateProfile(@RequestBody ProfileDto profileDto) {
+    updateProfileMessageReceiver.receiveCreateMessage(profileDto);
+    return ResponseEntity.ok().body(profileDto);
   }
 }

--- a/backend/profile-service/src/main/java/org/maxq/profileservice/controller/api/QaApi.java
+++ b/backend/profile-service/src/main/java/org/maxq/profileservice/controller/api/QaApi.java
@@ -6,4 +6,6 @@ import org.springframework.http.ResponseEntity;
 public interface QaApi {
 
   ResponseEntity<ProfileDto> createProfile(ProfileDto profileDto);
+
+  ResponseEntity<ProfileDto> updateProfile(ProfileDto profileDto);
 }


### PR DESCRIPTION
Created endpoint for triggering profile update handler/listener through API for API tests. It accepts full ProfileDto object, unlike the Profile Controller PUT /profiles/me