### PR TITLE
[STORY] User should be able to change profile data

### DIFF
--- a/backend/api-gateway-service/src/main/resources/application.yaml
+++ b/backend/api-gateway-service/src/main/resources/application.yaml
@@ -50,7 +50,7 @@ spring:
               uri: lb://profile-service
               predicates:
                 - Path=/api/profile/**
-                - Method=GET
+                - Method=GET,PUT
                 - Header=Content-Type, application/json
               filters:
                 - AddRequestHeader=X-Gateway, api-gateway-service

--- a/backend/profile-service/build.gradle
+++ b/backend/profile-service/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     implementation 'org.springframework.security:spring-security-oauth2-jose'

--- a/backend/profile-service/src/main/java/org/maxq/profileservice/config/message/RabbitmqConfig.java
+++ b/backend/profile-service/src/main/java/org/maxq/profileservice/config/message/RabbitmqConfig.java
@@ -17,8 +17,12 @@ public class RabbitmqConfig {
   private String topicExchangeName;
   @Value("${profile.queue.create}")
   private String createQueueName;
+  @Value("${profile.queue.update}")
+  private String updateQueueName;
   @Value("${profile.topic.create}")
   private String createTopicName;
+  @Value("${profile.topic.update}")
+  private String updateTopicName;
 
   @Bean
   public TopicExchange topicExchange() {
@@ -31,8 +35,18 @@ public class RabbitmqConfig {
   }
 
   @Bean
+  public Queue updateQueue() {
+    return new Queue(updateQueueName, false);
+  }
+
+  @Bean
   public Binding createProfileBinding(Queue createQueue, TopicExchange topicExchange) {
     return BindingBuilder.bind(createQueue).to(topicExchange).with(createTopicName);
+  }
+
+  @Bean
+  public Binding updateProfileBinding(Queue updateQueue, TopicExchange topicExchange) {
+    return BindingBuilder.bind(updateQueue).to(topicExchange).with(updateTopicName);
   }
 
   @Bean

--- a/backend/profile-service/src/main/java/org/maxq/profileservice/controller/ProfileController.java
+++ b/backend/profile-service/src/main/java/org/maxq/profileservice/controller/ProfileController.java
@@ -5,14 +5,15 @@ import org.maxq.profileservice.controller.api.ProfileApi;
 import org.maxq.profileservice.domain.Profile;
 import org.maxq.profileservice.domain.dto.ProfileDto;
 import org.maxq.profileservice.domain.exception.ElementNotFoundException;
+import org.maxq.profileservice.event.message.RabbitmqMessage;
 import org.maxq.profileservice.mapper.ProfileMapper;
 import org.maxq.profileservice.service.ProfileService;
+import org.maxq.profileservice.service.message.publisher.MessageService;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/profiles")
@@ -21,6 +22,10 @@ public class ProfileController implements ProfileApi {
 
   private final ProfileService profileService;
   private final ProfileMapper profileMapper;
+  private final MessageService<RabbitmqMessage<?>> messageService;
+
+  @Value("${profile.topic.update}")
+  private String updateProfileTopic;
 
   @Override
   @GetMapping("/me")
@@ -31,5 +36,15 @@ public class ProfileController implements ProfileApi {
     return ResponseEntity.ok(
         profileMapper.mapToProfileDto(foundProfile)
     );
+  }
+
+  @Override
+  @PutMapping
+  @PreAuthorize("authentication.principal == #profileDto.email")
+  public ResponseEntity<Void> updateProfile(Authentication authentication,
+                                            @RequestBody ProfileDto profileDto) {
+    RabbitmqMessage<ProfileDto> message = new RabbitmqMessage<>(profileDto, updateProfileTopic);
+    messageService.sendMessage(message);
+    return ResponseEntity.ok().build();
   }
 }

--- a/backend/profile-service/src/main/java/org/maxq/profileservice/controller/QaController.java
+++ b/backend/profile-service/src/main/java/org/maxq/profileservice/controller/QaController.java
@@ -4,13 +4,11 @@ import lombok.RequiredArgsConstructor;
 import org.maxq.profileservice.controller.api.QaApi;
 import org.maxq.profileservice.domain.dto.ProfileDto;
 import org.maxq.profileservice.service.message.listener.CreateProfileMessageReceiver;
+import org.maxq.profileservice.service.message.listener.UpdateProfileMessageReceiver;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/qa")
@@ -19,11 +17,19 @@ import org.springframework.web.bind.annotation.RestController;
 public class QaController implements QaApi {
 
   private final CreateProfileMessageReceiver createProfileMessageReceiver;
+  private final UpdateProfileMessageReceiver updateProfileMessageReceiver;
 
   @Override
   @PostMapping("/profiles")
   public ResponseEntity<ProfileDto> createProfile(@RequestBody ProfileDto profileDto) {
     createProfileMessageReceiver.receiveUpdateMessage(profileDto);
     return ResponseEntity.status(HttpStatus.CREATED).body(profileDto);
+  }
+
+  @Override
+  @PutMapping("/profiles")
+  public ResponseEntity<ProfileDto> updateProfile(@RequestBody ProfileDto profileDto) {
+    updateProfileMessageReceiver.receiveCreateMessage(profileDto);
+    return ResponseEntity.ok().body(profileDto);
   }
 }

--- a/backend/profile-service/src/main/java/org/maxq/profileservice/controller/QaController.java
+++ b/backend/profile-service/src/main/java/org/maxq/profileservice/controller/QaController.java
@@ -23,7 +23,7 @@ public class QaController implements QaApi {
   @Override
   @PostMapping("/profiles")
   public ResponseEntity<ProfileDto> createProfile(@RequestBody ProfileDto profileDto) {
-    createProfileMessageReceiver.receiveCreateMessage(profileDto);
+    createProfileMessageReceiver.receiveUpdateMessage(profileDto);
     return ResponseEntity.status(HttpStatus.CREATED).body(profileDto);
   }
 }

--- a/backend/profile-service/src/main/java/org/maxq/profileservice/controller/api/ProfileApi.java
+++ b/backend/profile-service/src/main/java/org/maxq/profileservice/controller/api/ProfileApi.java
@@ -26,6 +26,11 @@ public interface ProfileApi {
               schema = @Schema(implementation = ProfileDto.class)
           )
       })
+  @ApiResponse(responseCode = "400",
+      description = "Validation errors for provided request body",
+      content = {
+          @Content(mediaType = "application/json", schema = @Schema(implementation = HttpErrorMessage.class))
+      })
   @ApiResponse(responseCode = "401",
       description = "Unauthenticated - only request with Robot Token are passed",
       content = {
@@ -48,7 +53,7 @@ public interface ProfileApi {
       summary = "Update profile information",
       description = "Allows to update profile data"
   )
-  @ApiResponse(responseCode = "200", description = "User information properly returned")
+  @ApiResponse(responseCode = "200", description = "User update message properly sent")
   @ApiResponse(responseCode = "401",
       description = "Unauthenticated - only request with Robot Token are passed",
       content = {
@@ -56,11 +61,6 @@ public interface ProfileApi {
       })
   @ApiResponse(responseCode = "403",
       description = "Unauthorized - only logged in users can access this resource",
-      content = {
-          @Content(mediaType = "application/json", schema = @Schema(implementation = HttpErrorMessage.class))
-      })
-  @ApiResponse(responseCode = "404",
-      description = "Not found - profile does not exist",
       content = {
           @Content(mediaType = "application/json", schema = @Schema(implementation = HttpErrorMessage.class))
       })

--- a/backend/profile-service/src/main/java/org/maxq/profileservice/controller/api/ProfileApi.java
+++ b/backend/profile-service/src/main/java/org/maxq/profileservice/controller/api/ProfileApi.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.maxq.profileservice.domain.HttpErrorMessage;
 import org.maxq.profileservice.domain.dto.ProfileDto;
+import org.maxq.profileservice.domain.dto.UpdateProfileDto;
 import org.maxq.profileservice.domain.exception.ElementNotFoundException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -54,8 +55,7 @@ public interface ProfileApi {
           @Content(mediaType = "application/json", schema = @Schema(implementation = HttpErrorMessage.class))
       })
   @ApiResponse(responseCode = "403",
-      description = "Unauthorized - only logged in users can access this resource, or tried to " +
-          "access profile of other user",
+      description = "Unauthorized - only logged in users can access this resource",
       content = {
           @Content(mediaType = "application/json", schema = @Schema(implementation = HttpErrorMessage.class))
       })
@@ -64,6 +64,6 @@ public interface ProfileApi {
       content = {
           @Content(mediaType = "application/json", schema = @Schema(implementation = HttpErrorMessage.class))
       })
-  ResponseEntity<Void> updateProfile(Authentication authentication, ProfileDto profileDto)
+  ResponseEntity<Void> updateProfile(Authentication authentication, UpdateProfileDto profileDto)
       throws ElementNotFoundException;
 }

--- a/backend/profile-service/src/main/java/org/maxq/profileservice/controller/api/ProfileApi.java
+++ b/backend/profile-service/src/main/java/org/maxq/profileservice/controller/api/ProfileApi.java
@@ -42,4 +42,28 @@ public interface ProfileApi {
       })
   ResponseEntity<ProfileDto> getMyProfile(Authentication authentication)
       throws ElementNotFoundException;
+
+  @Operation(
+      summary = "Update profile information",
+      description = "Allows to update profile data"
+  )
+  @ApiResponse(responseCode = "200", description = "User information properly returned")
+  @ApiResponse(responseCode = "401",
+      description = "Unauthenticated - only request with Robot Token are passed",
+      content = {
+          @Content(mediaType = "application/json", schema = @Schema(implementation = HttpErrorMessage.class))
+      })
+  @ApiResponse(responseCode = "403",
+      description = "Unauthorized - only logged in users can access this resource, or tried to " +
+          "access profile of other user",
+      content = {
+          @Content(mediaType = "application/json", schema = @Schema(implementation = HttpErrorMessage.class))
+      })
+  @ApiResponse(responseCode = "404",
+      description = "Not found - profile does not exist",
+      content = {
+          @Content(mediaType = "application/json", schema = @Schema(implementation = HttpErrorMessage.class))
+      })
+  ResponseEntity<Void> updateProfile(Authentication authentication, ProfileDto profileDto)
+      throws ElementNotFoundException;
 }

--- a/backend/profile-service/src/main/java/org/maxq/profileservice/controller/api/QaApi.java
+++ b/backend/profile-service/src/main/java/org/maxq/profileservice/controller/api/QaApi.java
@@ -6,4 +6,6 @@ import org.springframework.http.ResponseEntity;
 public interface QaApi {
 
   ResponseEntity<ProfileDto> createProfile(ProfileDto profileDto);
+
+  ResponseEntity<ProfileDto> updateProfile(ProfileDto profileDto);
 }

--- a/backend/profile-service/src/main/java/org/maxq/profileservice/domain/dto/ProfileDto.java
+++ b/backend/profile-service/src/main/java/org/maxq/profileservice/domain/dto/ProfileDto.java
@@ -16,4 +16,11 @@ public class ProfileDto {
   private String firstName;
   private String middleName;
   private String lastName;
+
+  public ProfileDto(String email, String firstName, String middleName, String lastName) {
+    this.email = email;
+    this.firstName = firstName;
+    this.middleName = middleName;
+    this.lastName = lastName;
+  }
 }

--- a/backend/profile-service/src/main/java/org/maxq/profileservice/domain/dto/ProfileDto.java
+++ b/backend/profile-service/src/main/java/org/maxq/profileservice/domain/dto/ProfileDto.java
@@ -11,6 +11,7 @@ import lombok.ToString;
 @ToString
 public class ProfileDto {
 
+  private Long id;
   private String email;
   private String firstName;
   private String middleName;

--- a/backend/profile-service/src/main/java/org/maxq/profileservice/domain/dto/UpdateProfileDto.java
+++ b/backend/profile-service/src/main/java/org/maxq/profileservice/domain/dto/UpdateProfileDto.java
@@ -1,0 +1,18 @@
+package org.maxq.profileservice.domain.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class UpdateProfileDto {
+
+  @NotNull
+  private String firstName;
+  private String middleName;
+  @NotNull
+  private String lastName;
+}

--- a/backend/profile-service/src/main/java/org/maxq/profileservice/domain/dto/UpdateProfileDto.java
+++ b/backend/profile-service/src/main/java/org/maxq/profileservice/domain/dto/UpdateProfileDto.java
@@ -1,6 +1,6 @@
 package org.maxq.profileservice.domain.dto;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,9 +10,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class UpdateProfileDto {
 
-  @NotNull
+  @NotBlank(message = "First name cannot be empty")
   private String firstName;
   private String middleName;
-  @NotNull
+  @NotBlank(message = "Last name cannot be empty")
   private String lastName;
 }

--- a/backend/profile-service/src/main/java/org/maxq/profileservice/event/message/Message.java
+++ b/backend/profile-service/src/main/java/org/maxq/profileservice/event/message/Message.java
@@ -1,0 +1,11 @@
+package org.maxq.profileservice.event.message;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public abstract class Message<T> {
+  private final T payload;
+}
+

--- a/backend/profile-service/src/main/java/org/maxq/profileservice/event/message/RabbitmqMessage.java
+++ b/backend/profile-service/src/main/java/org/maxq/profileservice/event/message/RabbitmqMessage.java
@@ -1,0 +1,15 @@
+package org.maxq.profileservice.event.message;
+
+import lombok.Getter;
+
+@Getter
+public class RabbitmqMessage<T> extends Message<T> {
+
+  private final String topic;
+
+  public RabbitmqMessage(T payload, String topic) {
+    super(payload);
+    this.topic = topic;
+  }
+}
+

--- a/backend/profile-service/src/main/java/org/maxq/profileservice/mapper/ProfileMapper.java
+++ b/backend/profile-service/src/main/java/org/maxq/profileservice/mapper/ProfileMapper.java
@@ -9,6 +9,7 @@ public class ProfileMapper {
 
   public ProfileDto mapToProfileDto(Profile profile) {
     return new ProfileDto(
+        profile.getId(),
         profile.getEmail(),
         profile.getFirstName(),
         profile.getMiddleName(),
@@ -18,6 +19,7 @@ public class ProfileMapper {
 
   public Profile mapToProfile(ProfileDto profileDto) {
     return new Profile(
+        profileDto.getId(),
         profileDto.getEmail(),
         profileDto.getFirstName(),
         profileDto.getMiddleName(),

--- a/backend/profile-service/src/main/java/org/maxq/profileservice/service/ProfileService.java
+++ b/backend/profile-service/src/main/java/org/maxq/profileservice/service/ProfileService.java
@@ -1,6 +1,7 @@
 package org.maxq.profileservice.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.maxq.profileservice.domain.Profile;
 import org.maxq.profileservice.domain.exception.DataValidationException;
 import org.maxq.profileservice.domain.exception.DuplicateEmailException;
@@ -10,6 +11,7 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.TransactionSystemException;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ProfileService {
@@ -31,6 +33,23 @@ public class ProfileService {
     } catch (DataIntegrityViolationException e) {
       throw new DuplicateEmailException(
           "User with this email already exists! Email: " + profile.getEmail(), e);
+    }
+  }
+
+  public void updateProfile(Profile profile) throws DataValidationException {
+    Profile profileToSave;
+    try {
+      Profile foundProfile = this.getProfileByEmail(profile.getEmail());
+      profileToSave = new Profile(foundProfile.getId(), profile.getEmail(), profile.getFirstName(), profile.getMiddleName(), profile.getLastName());
+    } catch (ElementNotFoundException e) {
+      log.warn("Profile not found when updating, creating new profile: {}", profile.getEmail(), e);
+      profileToSave = new Profile(profile.getEmail(), profile.getFirstName(), profile.getMiddleName(), profile.getLastName());
+    }
+
+    try {
+      profileRepository.save(profileToSave);
+    } catch (TransactionSystemException e) {
+      throw new DataValidationException("Failed email or password validation", e);
     }
   }
 

--- a/backend/profile-service/src/main/java/org/maxq/profileservice/service/message/handler/UpdateProfileHandler.java
+++ b/backend/profile-service/src/main/java/org/maxq/profileservice/service/message/handler/UpdateProfileHandler.java
@@ -1,0 +1,31 @@
+package org.maxq.profileservice.service.message.handler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.maxq.profileservice.domain.Profile;
+import org.maxq.profileservice.domain.dto.ProfileDto;
+import org.maxq.profileservice.domain.exception.DataValidationException;
+import org.maxq.profileservice.mapper.ProfileMapper;
+import org.maxq.profileservice.service.ProfileService;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UpdateProfileHandler implements MessageHandler<ProfileDto> {
+
+  private final ProfileService profileService;
+  private final ProfileMapper profileMapper;
+
+  @Override
+  public void handleMessage(ProfileDto message) {
+    log.info("Handling message with profile: {}", message);
+    Profile profile = profileMapper.mapToProfile(message);
+    try {
+      profileService.updateProfile(profile);
+      log.info("Profile update handled: {}", profile);
+    } catch (DataValidationException e) {
+      log.error("Failed to handle profile profile: {}", profile, e);
+    }
+  }
+}

--- a/backend/profile-service/src/main/java/org/maxq/profileservice/service/message/listener/UpdateProfileMessageReceiver.java
+++ b/backend/profile-service/src/main/java/org/maxq/profileservice/service/message/listener/UpdateProfileMessageReceiver.java
@@ -3,25 +3,25 @@ package org.maxq.profileservice.service.message.listener;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.maxq.profileservice.domain.dto.ProfileDto;
-import org.maxq.profileservice.service.message.handler.CreateProfileHandler;
+import org.maxq.profileservice.service.message.handler.UpdateProfileHandler;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class CreateProfileMessageReceiver implements MessageReceiver<ProfileDto> {
+public class UpdateProfileMessageReceiver implements MessageReceiver<ProfileDto> {
 
-  private final CreateProfileHandler createProfileHandler;
+  private final UpdateProfileHandler updateProfileHandler;
 
-  @RabbitListener(id = "createProfileReceiver", queues = "${profile.queue.create}")
-  public void receiveUpdateMessage(ProfileDto profile) {
+  @RabbitListener(id = "updateProfileReceiver", queues = "${profile.queue.update}")
+  public void receiveCreateMessage(ProfileDto profile) {
     receiveMessage(profile);
   }
 
   @Override
   public void receiveMessage(ProfileDto profile) {
     log.info("Received message: {}", profile);
-    createProfileHandler.handleMessage(profile);
+    updateProfileHandler.handleMessage(profile);
   }
 }

--- a/backend/profile-service/src/main/java/org/maxq/profileservice/service/message/publisher/MessageService.java
+++ b/backend/profile-service/src/main/java/org/maxq/profileservice/service/message/publisher/MessageService.java
@@ -1,0 +1,9 @@
+package org.maxq.profileservice.service.message.publisher;
+
+import org.maxq.profileservice.event.message.Message;
+
+public interface MessageService<M extends Message<?>> {
+
+  void sendMessage(M message);
+}
+

--- a/backend/profile-service/src/main/java/org/maxq/profileservice/service/message/publisher/QAMessagingService.java
+++ b/backend/profile-service/src/main/java/org/maxq/profileservice/service/message/publisher/QAMessagingService.java
@@ -1,0 +1,17 @@
+package org.maxq.profileservice.service.message.publisher;
+
+import lombok.extern.slf4j.Slf4j;
+import org.maxq.profileservice.event.message.RabbitmqMessage;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+
+@Slf4j(topic = "Messaging Service Stub")
+@Service
+@Profile("QA")
+public class QAMessagingService implements MessageService<RabbitmqMessage<?>> {
+
+  @Override
+  public void sendMessage(RabbitmqMessage<?> message) {
+    log.info("Sending message: {} to topic: {}", message.getPayload(), message.getTopic());
+  }
+}

--- a/backend/profile-service/src/main/java/org/maxq/profileservice/service/message/publisher/RabbitmqMessageService.java
+++ b/backend/profile-service/src/main/java/org/maxq/profileservice/service/message/publisher/RabbitmqMessageService.java
@@ -1,8 +1,8 @@
-package org.maxq.authorization.service.message;
+package org.maxq.profileservice.service.message.publisher;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.maxq.authorization.event.message.RabbitmqMessage;
+import org.maxq.profileservice.event.message.RabbitmqMessage;
 import org.springframework.amqp.core.TopicExchange;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.context.annotation.Profile;

--- a/backend/profile-service/src/main/resources/application.yml
+++ b/backend/profile-service/src/main/resources/application.yml
@@ -15,9 +15,11 @@ app:
 profile:
   queue:
     create: "authorization-profile-create-queue"
+    update: "authorization-profile-update-queue"
   exchange: "authorization-profile-exchange"
   topic:
     create: "profile.create"
+    update: "profile.update"
 
 spring:
   application:

--- a/backend/profile-service/src/test/java/org/maxq/profileservice/controller/ProfileControllerTest.java
+++ b/backend/profile-service/src/test/java/org/maxq/profileservice/controller/ProfileControllerTest.java
@@ -1,16 +1,20 @@
 package org.maxq.profileservice.controller;
 
+import com.google.gson.Gson;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.maxq.profileservice.domain.Profile;
 import org.maxq.profileservice.domain.dto.ProfileDto;
 import org.maxq.profileservice.domain.exception.ElementNotFoundException;
+import org.maxq.profileservice.event.message.RabbitmqMessage;
 import org.maxq.profileservice.mapper.ProfileMapper;
 import org.maxq.profileservice.service.ProfileService;
+import org.maxq.profileservice.service.message.publisher.MessageService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers;
@@ -25,13 +29,15 @@ import org.springframework.web.context.WebApplicationContext;
 import java.time.Instant;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @SpringBootTest
 @WebAppConfiguration
 class ProfileControllerTest {
 
   private static final String URL = "/profiles";
+  private static final Gson GSON = new Gson();
+
   Jwt jwt = Jwt.withTokenValue("test-token")
       .header("alg", "RS256")
       .subject("robot")
@@ -40,14 +46,12 @@ class ProfileControllerTest {
       .issuedAt(Instant.now())
       .expiresAt(Instant.now().plusSeconds(3600))
       .build();
-
   String email = "test@test.com";
   String roles = "ROLE_TEST";
   Profile profile
-      = new Profile(email, "TestName", "testMiddleName", "TestLastName");
+      = new Profile(1L, email, "TestName", "testMiddleName", "TestLastName");
   ProfileDto profileDto
-      = new ProfileDto(email, profile.getFirstName(), profile.getMiddleName(), profile.getLastName());
-
+      = new ProfileDto(1L, email, profile.getFirstName(), profile.getMiddleName(), profile.getLastName());
   private MockMvc mockMvc;
 
   @Autowired
@@ -57,6 +61,8 @@ class ProfileControllerTest {
   private ProfileService profileService;
   @MockitoBean
   private ProfileMapper profileMapper;
+  @MockitoBean
+  private MessageService<RabbitmqMessage<?>> messageService;
 
   @MockitoBean
   private JwtDecoder jwtDecoder;
@@ -145,4 +151,86 @@ class ProfileControllerTest {
             .jsonPath("$.message", Matchers.is(error)));
   }
 
+  @Test
+  void shouldUpdateProfile() throws Exception {
+    // Given
+    when(profileService.getProfileByEmail(email)).thenReturn(profile);
+    ProfileDto updatedProfile = new ProfileDto(
+        profileDto.getId(), profileDto.getEmail(),
+        "UpdatedName", null, "UpdatedLastName");
+
+    // When + Then
+    mockMvc.perform(MockMvcRequestBuilders
+            .put(URL)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(GSON.toJson(updatedProfile))
+            .header(HttpHeaders.AUTHORIZATION, "Bearer test-token")
+            .header("X-User", email)
+            .header("X-User-Roles", roles))
+        .andExpect(MockMvcResultMatchers.status().isOk());
+    verify(messageService, times(1))
+        .sendMessage(argThat(message -> "profile.update".equals(message.getTopic())));
+    verify(messageService, times(1))
+        .sendMessage(argThat(message -> email.equals(((ProfileDto) message.getPayload()).getEmail())));
+  }
+
+  @Test
+  void shouldThrow401_When_NoRobotToken_OnUpdate() throws Exception {
+    // Given
+    when(profileService.getProfileByEmail(email)).thenReturn(profile);
+    ProfileDto updatedProfile = new ProfileDto(
+        profileDto.getId(), profileDto.getEmail(),
+        "UpdatedName", null, "UpdatedLastName");
+
+    // When + Then
+    mockMvc.perform(MockMvcRequestBuilders
+            .put(URL)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(GSON.toJson(updatedProfile))
+            .header("X-User", email)
+            .header("X-User-Roles", roles))
+        .andExpect(MockMvcResultMatchers.status().isUnauthorized())
+        .andExpect(MockMvcResultMatchers
+            .jsonPath("$.message", Matchers.is("Unauthorized to access this resource, login please")));
+  }
+
+  @Test
+  void shouldThrow403_When_NoUserHeaders_OnUpdate() throws Exception {
+    // Given
+    when(profileService.getProfileByEmail(email)).thenReturn(profile);
+    ProfileDto updatedProfile = new ProfileDto(
+        profileDto.getId(), profileDto.getEmail(),
+        "UpdatedName", null, "UpdatedLastName");
+
+    // When + Then
+    mockMvc.perform(MockMvcRequestBuilders
+            .put(URL)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(GSON.toJson(updatedProfile))
+            .header(HttpHeaders.AUTHORIZATION, "Bearer test-token"))
+        .andExpect(MockMvcResultMatchers.status().isForbidden())
+        .andExpect(MockMvcResultMatchers
+            .jsonPath("$.message", Matchers.is("Forbidden: You don't have permission to access this resource")));
+  }
+
+  @Test
+  void shouldThrow403_When_UserNotMatchUpdate() throws Exception {
+    // Given
+    when(profileService.getProfileByEmail(email)).thenReturn(profile);
+    ProfileDto updatedProfile = new ProfileDto(
+        profileDto.getId(), profileDto.getEmail(),
+        "UpdatedName", null, "UpdatedLastName");
+
+    // When + Then
+    mockMvc.perform(MockMvcRequestBuilders
+            .put(URL)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(GSON.toJson(updatedProfile))
+            .header("X-User", "other@email.com")
+            .header("X-User-Roles", roles)
+            .header(HttpHeaders.AUTHORIZATION, "Bearer test-token"))
+        .andExpect(MockMvcResultMatchers.status().isForbidden())
+        .andExpect(MockMvcResultMatchers
+            .jsonPath("$.message", Matchers.is("Forbidden: You don't have permission to access this resource")));
+  }
 }

--- a/backend/profile-service/src/test/java/org/maxq/profileservice/controller/ProfileControllerTest.java
+++ b/backend/profile-service/src/test/java/org/maxq/profileservice/controller/ProfileControllerTest.java
@@ -161,7 +161,7 @@ class ProfileControllerTest {
 
     // When + Then
     mockMvc.perform(MockMvcRequestBuilders
-            .put(URL)
+            .put(URL + "/me")
             .contentType(MediaType.APPLICATION_JSON)
             .content(GSON.toJson(updatedProfile))
             .header(HttpHeaders.AUTHORIZATION, "Bearer test-token")
@@ -184,7 +184,7 @@ class ProfileControllerTest {
 
     // When + Then
     mockMvc.perform(MockMvcRequestBuilders
-            .put(URL)
+            .put(URL + "/me")
             .contentType(MediaType.APPLICATION_JSON)
             .content(GSON.toJson(updatedProfile))
             .header("X-User", email)
@@ -204,30 +204,9 @@ class ProfileControllerTest {
 
     // When + Then
     mockMvc.perform(MockMvcRequestBuilders
-            .put(URL)
+            .put(URL + "/me")
             .contentType(MediaType.APPLICATION_JSON)
             .content(GSON.toJson(updatedProfile))
-            .header(HttpHeaders.AUTHORIZATION, "Bearer test-token"))
-        .andExpect(MockMvcResultMatchers.status().isForbidden())
-        .andExpect(MockMvcResultMatchers
-            .jsonPath("$.message", Matchers.is("Forbidden: You don't have permission to access this resource")));
-  }
-
-  @Test
-  void shouldThrow403_When_UserNotMatchUpdate() throws Exception {
-    // Given
-    when(profileService.getProfileByEmail(email)).thenReturn(profile);
-    ProfileDto updatedProfile = new ProfileDto(
-        profileDto.getId(), profileDto.getEmail(),
-        "UpdatedName", null, "UpdatedLastName");
-
-    // When + Then
-    mockMvc.perform(MockMvcRequestBuilders
-            .put(URL)
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(GSON.toJson(updatedProfile))
-            .header("X-User", "other@email.com")
-            .header("X-User-Roles", roles)
             .header(HttpHeaders.AUTHORIZATION, "Bearer test-token"))
         .andExpect(MockMvcResultMatchers.status().isForbidden())
         .andExpect(MockMvcResultMatchers

--- a/backend/profile-service/src/test/java/org/maxq/profileservice/mapper/ProfileMapperTest.java
+++ b/backend/profile-service/src/test/java/org/maxq/profileservice/mapper/ProfileMapperTest.java
@@ -17,13 +17,15 @@ class ProfileMapperTest {
   @Test
   void shouldMapToProfileDto() {
     // Given
-    Profile profile = new Profile("test@test.com", "test", "testMiddleName", "testLastName");
+    Profile profile = new Profile(1L, "test@test.com", "test", "testMiddleName", "testLastName");
 
     // When
     ProfileDto profileDto = profileMapper.mapToProfileDto(profile);
 
     // Then
     assertAll(
+        () -> assertEquals(profile.getId(), profileDto.getId(),
+            "Profile should map equal id"),
         () -> assertEquals(profile.getEmail(), profileDto.getEmail(),
             "Profile should map equal email"),
         () -> assertEquals(profile.getFirstName(), profileDto.getFirstName(),
@@ -38,13 +40,15 @@ class ProfileMapperTest {
   @Test
   void shouldMapToProfileDto_When_MiddleNameNull() {
     // Given
-    Profile profile = new Profile("test@test.com", "test", "testLastName");
+    Profile profile = new Profile(1L, "test@test.com", "test", null, "testLastName");
 
     // When
     ProfileDto profileDto = profileMapper.mapToProfileDto(profile);
 
     // Then
     assertAll(
+        () -> assertEquals(profile.getId(), profileDto.getId(),
+            "Profile should map equal id"),
         () -> assertEquals(profile.getEmail(), profileDto.getEmail(),
             "Profile should map equal email"),
         () -> assertEquals(profile.getFirstName(), profileDto.getFirstName(),
@@ -60,6 +64,7 @@ class ProfileMapperTest {
   void shouldMapToProfile() {
     // Given
     ProfileDto profileDto = new ProfileDto(
+        1L,
         "test@test.com",
         "test",
         "testMiddleName",
@@ -70,6 +75,8 @@ class ProfileMapperTest {
 
     // Then
     assertAll(
+        () -> assertEquals(profileDto.getId(), profile.getId(),
+            "Profile should map equal id"),
         () -> assertEquals(profileDto.getEmail(), profile.getEmail(),
             "Profile should map equal email"),
         () -> assertEquals(profileDto.getFirstName(), profile.getFirstName(),
@@ -85,6 +92,7 @@ class ProfileMapperTest {
   void shouldMapToProfile_When_MiddleNameNull() {
     // Given
     ProfileDto profileDto = new ProfileDto(
+        1L,
         "test@test.com",
         "test",
         null,
@@ -95,6 +103,8 @@ class ProfileMapperTest {
 
     // Then
     assertAll(
+        () -> assertEquals(profileDto.getId(), profile.getId(),
+            "Profile should map equal id"),
         () -> assertEquals(profileDto.getEmail(), profile.getEmail(),
             "Profile should map equal email"),
         () -> assertEquals(profileDto.getFirstName(), profile.getFirstName(),

--- a/backend/profile-service/src/test/java/org/maxq/profileservice/repository/ProfileRepositoryTest.java
+++ b/backend/profile-service/src/test/java/org/maxq/profileservice/repository/ProfileRepositoryTest.java
@@ -93,6 +93,33 @@ class ProfileRepositoryTest {
   }
 
   @Test
+  void shouldUpdateProfile() {
+    // Given
+    profileRepository.save(profile);
+    Profile updatedProfile = new Profile(
+        profile.getId(), profile.getEmail(),
+        "UpdatedName", "UpdatedMiddleName", "UpdatedLastName"
+    );
+
+    // When
+    profileRepository.save(updatedProfile);
+    Optional<Profile> foundProfile = profileRepository.findById(profile.getId());
+
+    // Then
+    assertTrue(foundProfile.isPresent(), "Profile should be found after update");
+    assertAll(
+        () -> assertEquals(updatedProfile.getEmail(), foundProfile.get().getEmail(),
+            "Profile should save with equal email"),
+        () -> assertEquals(updatedProfile.getFirstName(), foundProfile.get().getFirstName(),
+            "Profile should save with equal first name"),
+        () -> assertEquals(updatedProfile.getMiddleName(), foundProfile.get().getMiddleName(),
+            "Middle name should be null"),
+        () -> assertEquals(updatedProfile.getLastName(), foundProfile.get().getLastName(),
+            "Profile should save with equal last name")
+    );
+  }
+
+  @Test
   void shouldFindByEmail() {
     // Given
     profileRepository.save(profile);

--- a/backend/profile-service/src/test/java/org/maxq/profileservice/service/message/handler/CreateProfileHandlerTest.java
+++ b/backend/profile-service/src/test/java/org/maxq/profileservice/service/message/handler/CreateProfileHandlerTest.java
@@ -1,4 +1,4 @@
-package org.maxq.profileservice.service.handler;
+package org.maxq.profileservice.service.message.handler;
 
 import org.junit.jupiter.api.Test;
 import org.maxq.profileservice.domain.Profile;
@@ -7,7 +7,6 @@ import org.maxq.profileservice.domain.exception.DataValidationException;
 import org.maxq.profileservice.domain.exception.DuplicateEmailException;
 import org.maxq.profileservice.mapper.ProfileMapper;
 import org.maxq.profileservice.service.ProfileService;
-import org.maxq.profileservice.service.message.handler.CreateProfileHandler;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -29,7 +28,7 @@ class CreateProfileHandlerTest {
   @Test
   void shouldCreateProfile() throws DataValidationException, DuplicateEmailException {
     // Given
-    ProfileDto profileDto = new ProfileDto("test@test.com", "Test", null, "User");
+    ProfileDto profileDto = new ProfileDto(1L, "test@test.com", "Test", null, "User");
     Profile profile = new Profile(profileDto.getEmail(), profileDto.getFirstName(), profileDto.getLastName());
     when(profileMapper.mapToProfile(profileDto)).thenReturn(profile);
 
@@ -42,7 +41,7 @@ class CreateProfileHandlerTest {
   void shouldNotThrow_When_CreateProfileThrows() throws DataValidationException,
       DuplicateEmailException {
     // Given
-    ProfileDto profileDto = new ProfileDto("test@test.com", "Test", null, "User");
+    ProfileDto profileDto = new ProfileDto(1L, "test@test.com", "Test", null, "User");
     Profile profile = new Profile(profileDto.getEmail(), profileDto.getFirstName(), profileDto.getLastName());
     when(profileMapper.mapToProfile(profileDto)).thenReturn(profile);
     doThrow(DuplicateEmailException.class).when(profileService).createProfile(profile);

--- a/backend/profile-service/src/test/java/org/maxq/profileservice/service/message/handler/UpdateProfileHandlerTest.java
+++ b/backend/profile-service/src/test/java/org/maxq/profileservice/service/message/handler/UpdateProfileHandlerTest.java
@@ -1,0 +1,69 @@
+package org.maxq.profileservice.service.message.handler;
+
+import org.junit.jupiter.api.Test;
+import org.maxq.profileservice.domain.Profile;
+import org.maxq.profileservice.domain.dto.ProfileDto;
+import org.maxq.profileservice.domain.exception.DataValidationException;
+import org.maxq.profileservice.mapper.ProfileMapper;
+import org.maxq.profileservice.service.ProfileService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+class UpdateProfileHandlerTest {
+
+  @Autowired
+  private UpdateProfileHandler handler;
+
+  @MockitoBean
+  private ProfileService profileService;
+  @MockitoBean
+  private ProfileMapper profileMapper;
+
+  @Test
+  void shouldHandleMessage() throws DataValidationException {
+    // Given
+    ProfileDto profileDto
+        = new ProfileDto(null, "test@test.com", "UpdateName", "UpdateMiddleName", "UpdateLastName");
+    Profile profile = new Profile(
+        profileDto.getId(),
+        profileDto.getEmail(), profileDto.getFirstName(),
+        profileDto.getMiddleName(), profileDto.getLastName()
+    );
+    when(profileMapper.mapToProfile(profileDto)).thenReturn(profile);
+
+    // When
+    handler.handleMessage(profileDto);
+
+    // Then
+    verify(profileService, times(1))
+        .updateProfile(argThat(profileCall ->
+            profileCall.getId() == null
+                && profile.getEmail().equals(profileCall.getEmail())
+                && profile.getFirstName().equals(profileCall.getFirstName())
+                && profile.getMiddleName().equals(profileCall.getMiddleName())
+                && profile.getLastName().equals(profileCall.getLastName())
+        ));
+  }
+
+  @Test
+  void shouldNotThrow_When_UpdateThrows() throws DataValidationException {
+    // Given
+    ProfileDto profileDto
+        = new ProfileDto(null, "test@test.com", "UpdateName", "UpdateMiddleName", "UpdateLastName");
+    Profile profile = new Profile(
+        profileDto.getId(),
+        profileDto.getEmail(), profileDto.getFirstName(),
+        profileDto.getMiddleName(), profileDto.getLastName()
+    );
+    when(profileMapper.mapToProfile(profileDto)).thenReturn(profile);
+    doThrow(DataValidationException.class).when(profileService).updateProfile(any(Profile.class));
+
+    // When + Then
+    assertDoesNotThrow(() -> handler.handleMessage(profileDto));
+  }
+}

--- a/backend/profile-service/src/test/java/org/maxq/profileservice/service/message/listener/CreateProfileMessageReceiverTest.java
+++ b/backend/profile-service/src/test/java/org/maxq/profileservice/service/message/listener/CreateProfileMessageReceiverTest.java
@@ -1,9 +1,8 @@
-package org.maxq.profileservice.service.message;
+package org.maxq.profileservice.service.message.listener;
 
 import org.junit.jupiter.api.Test;
 import org.maxq.profileservice.domain.dto.ProfileDto;
 import org.maxq.profileservice.service.message.handler.CreateProfileHandler;
-import org.maxq.profileservice.service.message.listener.CreateProfileMessageReceiver;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -23,7 +22,7 @@ class CreateProfileMessageReceiverTest {
   @Test
   void shouldReceiveMessage() {
     // Given
-    ProfileDto profileDto = new ProfileDto("test@test.com", "Test", null, "User");
+    ProfileDto profileDto = new ProfileDto(1L, "test@test.com", "Test", null, "User");
 
     // When
     messageReceiver.receiveCreateMessage(profileDto);

--- a/backend/profile-service/src/test/java/org/maxq/profileservice/service/message/listener/CreateProfileMessageReceiverTest.java
+++ b/backend/profile-service/src/test/java/org/maxq/profileservice/service/message/listener/CreateProfileMessageReceiverTest.java
@@ -25,7 +25,7 @@ class CreateProfileMessageReceiverTest {
     ProfileDto profileDto = new ProfileDto(1L, "test@test.com", "Test", null, "User");
 
     // When
-    messageReceiver.receiveCreateMessage(profileDto);
+    messageReceiver.receiveUpdateMessage(profileDto);
 
     // Then
     verify(createProfileHandler, times(1)).handleMessage(profileDto);

--- a/backend/profile-service/src/test/java/org/maxq/profileservice/service/message/listener/UpdateProfileMessageReceiverTest.java
+++ b/backend/profile-service/src/test/java/org/maxq/profileservice/service/message/listener/UpdateProfileMessageReceiverTest.java
@@ -1,0 +1,41 @@
+package org.maxq.profileservice.service.message.listener;
+
+import org.junit.jupiter.api.Test;
+import org.maxq.profileservice.domain.dto.ProfileDto;
+import org.maxq.profileservice.service.message.handler.UpdateProfileHandler;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@SpringBootTest
+class UpdateProfileMessageReceiverTest {
+
+  @Autowired
+  private UpdateProfileMessageReceiver messageReceiver;
+
+  @MockitoBean
+  private UpdateProfileHandler updateProfileHandler;
+
+  @Test
+  void shouldReceiveCreateMessage() {
+    // Give
+    ProfileDto profileDto
+        = new ProfileDto(null, "test@test.com", "UpdateName", "UpdateMiddleName", "UpdateLastName");
+
+    // When
+    messageReceiver.receiveCreateMessage(profileDto);
+
+    // Then
+    verify(updateProfileHandler, times(1))
+        .handleMessage(argThat(profile ->
+            profileDto.getEmail().equals(profile.getEmail())
+                && profileDto.getFirstName().equals(profile.getFirstName())
+                && profileDto.getMiddleName().equals(profile.getMiddleName())
+                && profileDto.getLastName().equals(profile.getLastName())
+        ));
+  }
+}

--- a/backend/profile-service/src/test/java/org/maxq/profileservice/service/message/publisher/RabbitmqMessageServiceTest.java
+++ b/backend/profile-service/src/test/java/org/maxq/profileservice/service/message/publisher/RabbitmqMessageServiceTest.java
@@ -1,0 +1,43 @@
+package org.maxq.profileservice.service.message.publisher;
+
+import org.junit.jupiter.api.Test;
+import org.maxq.profileservice.domain.dto.ProfileDto;
+import org.maxq.profileservice.event.message.RabbitmqMessage;
+import org.springframework.amqp.core.TopicExchange;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+@ActiveProfiles("DEV")
+class RabbitmqMessageServiceTest {
+
+  @Autowired
+  private RabbitmqMessageService messageService;
+
+  @MockitoBean
+  private TopicExchange topicExchange;
+  @MockitoBean
+  private RabbitTemplate rabbitTemplate;
+
+  @Test
+  void shouldPostMessage() {
+    // Given
+    String exchangeName = "exchange";
+    String topicName = "exchange.topic";
+    ProfileDto profileDto = new ProfileDto(1L, "test@test.com", "Test", null, "User");
+    RabbitmqMessage<ProfileDto> message = new RabbitmqMessage<>(profileDto, topicName);
+
+    when(topicExchange.getName()).thenReturn(exchangeName);
+
+    // When
+    messageService.sendMessage(message);
+
+    // Then
+    verify(rabbitTemplate, times(1)).convertAndSend(exchangeName, topicName, profileDto);
+  }
+}

--- a/backend/profile-service/src/test/resources/application.yml
+++ b/backend/profile-service/src/test/resources/application.yml
@@ -11,9 +11,11 @@ jwt:
 profile:
   queue:
     create: "authorization-profile-create-queue"
+    update: "authorization-profile-update-queue"
   exchange: "authorization-profile-exchange"
   topic:
     create: "profile.create"
+    update: "profile.update"
 
 spring:
   datasource:

--- a/frontend/src/components/profile/Profile.tsx
+++ b/frontend/src/components/profile/Profile.tsx
@@ -7,16 +7,21 @@ import {
   Link,
   Separator,
 } from '@radix-ui/themes';
-import { useMyProfileQuery } from '../../store/api/profile.ts';
+import {
+  useMyProfileQuery,
+  useUpdateMyProfileMutation,
+} from '../../store/api/profile.ts';
 import ProfileSection from './ProfileSection.tsx';
 import ProfileItem from './ProfileItem.tsx';
 import { FormEvent, useState } from 'react';
 import Form from '../shared/form/Form.tsx';
 import ProfileControls from './ProfileControls.tsx';
+import { UpdateProfileType } from '../../types/api/ProfileTypes.ts';
 
 const Profile = () => {
   const { data: profileData } = useMyProfileQuery();
   const [isEdited, setIsEdited] = useState(false);
+  const [updateProfile] = useUpdateMyProfileMutation();
 
   const firstNameFirstLetter = profileData?.firstName.charAt(0) ?? 'M';
   const lastNameFirstLetter = profileData?.lastName.charAt(0) ?? 'Q';
@@ -32,6 +37,17 @@ const Profile = () => {
   };
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
+
+    const fd = new FormData(event.currentTarget);
+    const data = Object.fromEntries(fd.entries());
+
+    const profile: UpdateProfileType = {
+      firstName: data['first name'] as string,
+      middleName: data['middle name'] as string,
+      lastName: data['last name'] as string,
+    };
+    void updateProfile(profile);
+    setIsEdited(false);
   };
 
   return (
@@ -59,14 +75,15 @@ const Profile = () => {
               <ProfileItem
                 isEdited={isEdited}
                 isLoading={!profileData}
-                title="First name"
+                title="first name"
+                required
               >
                 {profileData?.firstName ?? ''}
               </ProfileItem>
               <ProfileItem
                 isEdited={isEdited}
                 isLoading={!profileData}
-                title="Middle name"
+                title="middle name"
               >
                 {profileData?.middleName ?? ''}
               </ProfileItem>
@@ -74,14 +91,15 @@ const Profile = () => {
                 <ProfileItem
                   isEdited={isEdited}
                   isLoading={!profileData}
-                  title="Last name"
+                  title="last name"
+                  required
                 >
                   {profileData?.lastName ?? ''}
                 </ProfileItem>
               </Box>
             </Grid>
           </ProfileSection>
-          <ProfileSection title="Email Address">
+          <ProfileSection title="email address">
             <ProfileItem isEdited={false} isLoading={!profileData}>
               <Link href={`mailto:${profileData?.email}`}>
                 {profileData?.email ?? ''}

--- a/frontend/src/components/profile/ProfileControls.tsx
+++ b/frontend/src/components/profile/ProfileControls.tsx
@@ -23,7 +23,7 @@ const ProfileControls = ({
       gap="2"
     >
       {!isEdited && (
-        <Button size="4" my="3" onClick={onEdit}>
+        <Button size="4" my="3" onClick={onEdit} type="button">
           <Pencil1Icon className="size-(--font-size-5)" /> Edit profile
         </Button>
       )}
@@ -35,7 +35,13 @@ const ProfileControls = ({
             width="fit"
             icon={SaveIcon}
           />
-          <Button size="4" color="gray" variant="soft" onClick={onCancel}>
+          <Button
+            size="4"
+            color="gray"
+            variant="soft"
+            onClick={onCancel}
+            type="button"
+          >
             <Cross2Icon className="size-(--font-size-5)" /> Cancel
           </Button>
         </>

--- a/frontend/src/components/profile/ProfileItem.tsx
+++ b/frontend/src/components/profile/ProfileItem.tsx
@@ -1,10 +1,12 @@
 import { DataList, Skeleton } from '@radix-ui/themes';
 import { PropsWithChildren } from 'react';
 import { textContent } from '../../utils/reactChildren.ts';
-import FormInput from '../shared/form/sub/FormInput.tsx';
+import FormInput, {
+  RadixFormInputProps,
+} from '../shared/form/sub/FormInput.tsx';
 import clsx from 'clsx/lite';
 
-interface ProfileItemProps {
+interface ProfileItemProps extends RadixFormInputProps {
   isEdited: boolean;
   isLoading: boolean;
   title?: string;
@@ -15,6 +17,7 @@ const ProfileItem = ({
   isLoading,
   title,
   children,
+  ...rest
 }: PropsWithChildren<ProfileItemProps>) => {
   const itemClasses = clsx(
     title && 'py-(--space-3)',
@@ -31,6 +34,7 @@ const ProfileItem = ({
       )}
       {isEdited && (
         <FormInput
+          {...rest}
           id={title}
           placeholder={title}
           defaultValue={textContent(children)}

--- a/frontend/src/components/shared/form/sub/FormInput.tsx
+++ b/frontend/src/components/shared/form/sub/FormInput.tsx
@@ -15,7 +15,7 @@ import { EyeClosedIcon, EyeOpenIcon } from '@radix-ui/react-icons';
 import { ValidatorType } from '../../../../types/ValidatorTypes.ts';
 import { IconType } from '../../../../types/components/BaseTypes.ts';
 
-interface RadixFormInputProps extends TextField.RootProps {
+export interface RadixFormInputProps extends TextField.RootProps {
   icon?: IconType;
   validators?: ValidatorType[];
   onValueChange?: (value: string) => void;

--- a/frontend/src/types/api/ProfileTypes.ts
+++ b/frontend/src/types/api/ProfileTypes.ts
@@ -1,6 +1,8 @@
 export interface ProfileType {
   email: string;
   firstName: string;
-  middleName: string;
+  middleName?: string;
   lastName: string;
 }
+
+export type UpdateProfileType = Omit<ProfileType, 'email'>;

--- a/frontend/tests/components/profile/Profile.test.tsx
+++ b/frontend/tests/components/profile/Profile.test.tsx
@@ -1,9 +1,10 @@
 import * as profileApiModule from '../../../src/store/api/profile.ts';
-import { afterEach, beforeEach, expect } from 'vitest';
-import { ProfileType } from '../../../src/types/api/ProfileTypes.ts';
+import { afterEach, beforeEach, describe, expect } from 'vitest';
+import { ProfileType, UpdateProfileType, } from '../../../src/types/api/ProfileTypes.ts';
 import { renderWithProviders } from '../../test-utils.tsx';
 import { fireEvent, screen } from '@testing-library/react';
 import Profile from '../../../src/components/profile/Profile.tsx';
+import { UserEvent, userEvent } from '@testing-library/user-event';
 
 const profileData: ProfileType = {
   firstName: 'John',
@@ -13,6 +14,9 @@ const profileData: ProfileType = {
 };
 
 describe('Profile', () => {
+  const editButton = 'Edit profile';
+  const mockProfileUpdate = vi.fn();
+
   beforeEach(() => {
     vi.clearAllMocks();
 
@@ -23,6 +27,16 @@ describe('Profile', () => {
       data: profileData,
       refetch: vi.fn(),
     });
+    vi.spyOn(profileApiModule, 'useUpdateMyProfileMutation').mockReturnValue([
+      mockProfileUpdate,
+      {
+        isLoading: false,
+        isError: false,
+        isSuccess: false,
+        error: undefined,
+        reset: vi.fn(),
+      },
+    ]);
   });
 
   afterEach(() => {
@@ -44,7 +58,7 @@ describe('Profile', () => {
   it('Should contain personal information and email section', () => {
     // Given
     const personalInformationTitle = 'Personal Information';
-    const emailTitle = 'Email Address';
+    const emailTitle = 'email address';
     renderWithProviders(<Profile />);
 
     // When
@@ -64,7 +78,7 @@ describe('Profile', () => {
 
     // When
     const firstNameElement = screen.getByText(profileData.firstName);
-    const middleNameElement = screen.getByText(profileData.middleName);
+    const middleNameElement = screen.getByText(profileData.middleName ?? '');
     const lastNameElement = screen.getByText(profileData.lastName);
 
     // Then
@@ -85,8 +99,6 @@ describe('Profile', () => {
   });
 
   describe('Editability', () => {
-    const editButton = 'Edit profile';
-
     it('Should contain Edit profile button', () => {
       // Given
       renderWithProviders(<Profile />);
@@ -156,6 +168,122 @@ describe('Profile', () => {
 
       // then
       expect(textboxElements).toHaveLength(0);
+    });
+
+    it('Should stop editing profile, when save clicked', () => {
+      // Given
+      renderWithProviders(<Profile />);
+      const editButtonElement = screen.getByRole('button', {
+        name: editButton,
+      });
+      fireEvent.click(editButtonElement);
+
+      // When
+      const saveButtonElement = screen.getByRole('button', {
+        name: 'Save changes',
+      });
+      fireEvent.click(saveButtonElement);
+      const textboxElements = screen.queryAllByRole('textbox');
+
+      // then
+      expect(textboxElements).toHaveLength(0);
+    });
+  });
+
+  describe('Validation', () => {
+    const saveButton = 'Save changes';
+    let user: UserEvent;
+
+    beforeEach(() => {
+      user = userEvent.setup();
+    });
+
+    it('Should validate first name', async () => {
+      // Given
+      const errorMessage = 'first name is required';
+      renderWithProviders(<Profile />);
+      const editButtonElement = screen.getByRole('button', {
+        name: editButton,
+      });
+      await user.click(editButtonElement);
+
+      // When
+      const firstNameElement = screen.getByPlaceholderText('first name');
+      await user.clear(firstNameElement);
+
+      const saveButtonElement = screen.getByRole('button', {
+        name: saveButton,
+      });
+      await user.click(saveButtonElement);
+      const errorElement = await screen.findByText(errorMessage);
+
+      // Then
+      expect(errorElement).toBeInTheDocument();
+    });
+
+    it('Should validate last name', async () => {
+      // Given
+      const errorMessage = 'last name is required';
+      renderWithProviders(<Profile />);
+      const editButtonElement = screen.getByRole('button', {
+        name: editButton,
+      });
+      await user.click(editButtonElement);
+
+      // When
+      const lastNameElement = screen.getByPlaceholderText('last name');
+      await user.clear(lastNameElement);
+
+      const saveButtonElement = screen.getByRole('button', {
+        name: saveButton,
+      });
+      await user.click(saveButtonElement);
+      const errorElement = await screen.findByText(errorMessage);
+
+      // Then
+      expect(errorElement).toBeInTheDocument();
+    });
+  });
+
+  describe('Form submission', () => {
+    let user: UserEvent;
+    const saveButton = 'Save changes';
+    const updatedProfile: UpdateProfileType = {
+      firstName: 'UpdatedName',
+      middleName: 'UpdatedMiddleName',
+      lastName: 'UpdatedLastName',
+    };
+
+    beforeEach(() => {
+      user = userEvent.setup();
+    });
+
+    it('Should call update profile mutation, when save clicked', async () => {
+      // Given
+      renderWithProviders(<Profile />);
+      const editButtonElement = screen.getByRole('button', {
+        name: editButton,
+      });
+      await user.click(editButtonElement);
+      const firstNameElement = screen.getByPlaceholderText('first name');
+      const middleNameElement = screen.getByPlaceholderText('middle name');
+      const lastNameElement = screen.getByPlaceholderText('last name');
+
+      // When
+      await user.clear(firstNameElement);
+      await user.type(firstNameElement, updatedProfile.firstName);
+      await user.clear(middleNameElement);
+      await user.type(middleNameElement, updatedProfile.middleName ?? '');
+      await user.clear(lastNameElement);
+      await user.type(lastNameElement, updatedProfile.lastName);
+      const saveButtonElement = screen.getByRole('button', {
+        name: saveButton,
+      });
+      await user.click(saveButtonElement);
+
+      // Then
+      expect(mockProfileUpdate).toHaveBeenCalledOnce();
+      expect(mockProfileUpdate).toHaveBeenCalledWith(updatedProfile);
     });
   });
 });

--- a/postman-api-tests/profile-service/EWM - Profile Service.postman_collection.json
+++ b/postman-api-tests/profile-service/EWM - Profile Service.postman_collection.json
@@ -341,12 +341,360 @@
 								}
 							},
 							"response": []
+						},
+						{
+							"name": "GET /profiles/me",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test('Status code is 200', () => {\r",
+											"    pm.response.to.have.status(200);\r",
+											"});\r",
+											"\r",
+											"const response = pm.response.json();\r",
+											"\r",
+											"pm.test('Should contain correct email', () => {\r",
+											"    const adminEmail = pm.variables.get('createProfileEmail');\r",
+											"    pm.expect(response).to.haveOwnProperty('email').to.be.a('string');\r",
+											"    pm.expect(response.email).to.eql(adminEmail);\r",
+											"});\r",
+											"\r",
+											"pm.test('Should contain other profile info', () => {\r",
+											"    pm.expect(response).to.be.an('object');\r",
+											"    pm.expect(response).to.haveOwnProperty('firstName').to.be.a('string');\r",
+											"    pm.expect(response).to.haveOwnProperty('lastName').to.be.a('string');\r",
+											"\r",
+											"    const middleName = response.middleName;\r",
+											"    pm.expect(typeof middleName === 'string' || middleName === null).to.be.true;\r",
+											"})\r",
+											"\r",
+											"pm.test('Should contain correct first name and last name', () => {\r",
+											"    const firstName = pm.variables.get('createProfileFirstName');\r",
+											"    const lastName = pm.variables.get('createProfileLastName');\r",
+											"\r",
+											"    pm.expect(response.firstName).to.eql(firstName);\r",
+											"    pm.expect(response.lastName).to.eql(lastName);\r",
+											"})\r",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-User",
+										"value": "{{createProfileEmail}}",
+										"type": "text"
+									},
+									{
+										"key": "X-User-Roles",
+										"value": "ROLE_OPERATOR",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{profileServiceUrl}}/profiles/me",
+									"host": [
+										"{{profileServiceUrl}}"
+									],
+									"path": [
+										"profiles",
+										"me"
+									]
+								}
+							},
+							"response": []
 						}
 					]
 				},
 				{
 					"name": "Negative",
-					"item": []
+					"item": [
+						{
+							"name": "Create Duplicate Profile",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"const duplicateProfileFirstName = pm.variables.replaceIn('{{$randomFirstName}}');\r",
+											"pm.collectionVariables.set(\"duplicateProfileFirstName\", duplicateProfileFirstName);\r",
+											"\r",
+											"const duplicateProfileLastName = pm.variables.replaceIn('{{$randomLastName}}');\r",
+											"pm.collectionVariables.set(\"duplicateProfileLastName\", duplicateProfileLastName);"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 201\", () => {\r",
+											"    pm.response.to.have.status(201);\r",
+											"});"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n    \"email\": \"{{adminEmail}}\",\r\n    \"firstName\": \"{{duplicateProfileFirstName}}\",\r\n    \"lastName\": \"{{duplicateProfileLastName}}\"\r\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{profileServiceUrl}}/qa/profiles",
+									"host": [
+										"{{profileServiceUrl}}"
+									],
+									"path": [
+										"qa",
+										"profiles"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "GET /profiles/me",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test('Status code is 200', () => {\r",
+											"    pm.response.to.have.status(200);\r",
+											"});\r",
+											"\r",
+											"const response = pm.response.json();\r",
+											"\r",
+											"pm.test('Should contain correct email', () => {\r",
+											"    const adminEmail = pm.variables.get('adminEmail');\r",
+											"    pm.expect(response).to.haveOwnProperty('email').to.be.a('string');\r",
+											"    pm.expect(response.email).to.eql(adminEmail);\r",
+											"});\r",
+											"\r",
+											"pm.test('Should contain other profile info', () => {\r",
+											"    pm.expect(response).to.be.an('object');\r",
+											"    pm.expect(response).to.haveOwnProperty('firstName').to.be.a('string');\r",
+											"    pm.expect(response).to.haveOwnProperty('lastName').to.be.a('string');\r",
+											"\r",
+											"    const middleName = response.middleName;\r",
+											"    pm.expect(typeof middleName === 'string' || middleName === null).to.be.true;\r",
+											"})\r",
+											"\r",
+											"pm.test('Should contain correct first name and last name', () => {\r",
+											"    const firstName = pm.variables.get('duplicateProfileFirstName');\r",
+											"    const lastName = pm.variables.get('duplicateProfileLastName');\r",
+											"\r",
+											"    pm.expect(response.firstName).not.to.eql(firstName);\r",
+											"    pm.expect(response.lastName).not.to.eql(lastName);\r",
+											"})\r",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "X-User",
+										"value": "{{adminEmail}}",
+										"type": "text"
+									},
+									{
+										"key": "X-User-Roles",
+										"value": "{{adminRoles}}",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{profileServiceUrl}}/profiles/me",
+									"host": [
+										"{{profileServiceUrl}}"
+									],
+									"path": [
+										"profiles",
+										"me"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Update Profile",
+			"item": [
+				{
+					"name": "Publisher",
+					"item": [
+						{
+							"name": "Positive",
+							"item": []
+						},
+						{
+							"name": "Negative",
+							"item": []
+						}
+					]
+				},
+				{
+					"name": "Subscriber",
+					"item": [
+						{
+							"name": "Positive",
+							"item": [
+								{
+									"name": "Existing Profile",
+									"item": []
+								},
+								{
+									"name": "New Profile",
+									"item": []
+								}
+							]
+						}
+					]
+				},
+				{
+					"name": "Create Profile",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									"const updateProfileEmail = pm.variables.replaceIn('{{$randomEmail}}');\r",
+									"pm.collectionVariables.set(\"updateProfileEmail\", updateProfileEmail);"
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 201\", () => {\r",
+									"    pm.response.to.have.status(201);\r",
+									"});"
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"email\": \"{{updateProfileEmail}}\",\r\n    \"firstName\": \"{{$randomFirstName}}\",\r\n    \"lastName\": \"{{$randomLastName}}\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{profileServiceUrl}}/qa/profiles",
+							"host": [
+								"{{profileServiceUrl}}"
+							],
+							"path": [
+								"qa",
+								"profiles"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Update profile",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									"const updateProfileFirstName = pm.variables.replaceIn('{{$randomFirstName}}');\r",
+									"pm.collectionVariables.set(\"updateProfileFirstName\", updateProfileFirstName);\r",
+									"\r",
+									"const updateProfileLastName = pm.variables.replaceIn('{{$randomLastName}}');\r",
+									"pm.collectionVariables.set(\"updateProfileLastName\", updateProfileLastName);"
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {\r",
+									"    pm.response.to.have.status(200);\r",
+									"});"
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"method": "PUT",
+						"header": [
+							{
+								"key": "X-User",
+								"value": "{{updateProfileEmail}}",
+								"type": "text"
+							},
+							{
+								"key": "X-User-Roles",
+								"value": "ROLE_OPERATOR",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"firstName\": \"{{updateProfileFirstName}}\",\r\n    \"lastName\": \"{{updateProfileLastName}}\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{profileServiceUrl}}/profiles/me",
+							"host": [
+								"{{profileServiceUrl}}"
+							],
+							"path": [
+								"profiles",
+								"me"
+							]
+						}
+					},
+					"response": []
 				}
 			]
 		}
@@ -427,6 +775,18 @@
 		},
 		{
 			"key": "duplicateProfileLastName",
+			"value": ""
+		},
+		{
+			"key": "updateProfileEmail",
+			"value": ""
+		},
+		{
+			"key": "updateProfileFirstName",
+			"value": ""
+		},
+		{
+			"key": "updateProfileLastName",
 			"value": ""
 		}
 	]

--- a/uitests/tests/profile/profiles.spec.ts
+++ b/uitests/tests/profile/profiles.spec.ts
@@ -1,7 +1,12 @@
 import { expect, test } from "../base/baseTest";
 import { Credentials, Token } from "../types/Authorization";
 import { openHomePage, openProfilePage } from "../utils/navigation.utils";
-import { navigateToProfile } from "./profiles.utils";
+import {
+  clickEditProfile,
+  clickSaveProfile,
+  fillProfileDetails,
+  navigateToProfile
+} from "./profiles.utils";
 
 import credentials from "../../test-data/credentials.json";
 import profiles from "../../test-data/profiles.json";
@@ -9,6 +14,7 @@ import { ProfileData } from "../types/Profile";
 import { getMyProfile } from "../utils/profile.api.utils";
 import { loginApi } from "../utils/authorization.api.utils";
 import { buildContextStorage } from "../setup/setup.utils";
+import { faker } from "@faker-js/faker";
 
 test("TC22 - should navigate and display user profile", async ({
   adminPage,
@@ -91,4 +97,95 @@ test("TC23 - should show newly registered profile", async ({
       ).toBeVisible(),
     ]);
   });
+});
+
+test("TC24 - should update profile", async ({
+  apiContext,
+  registeredUser,
+  baseURL,
+  browser,
+}) => {
+  await test.step("TC24.1 - profile should already exits", async () => {
+    await expect(async () => {
+      // Given
+      const email = registeredUser.email;
+      const roles = ["ROLE_OPERATOR"];
+
+      // When
+      let profileData: ProfileData = await getMyProfile(
+        apiContext,
+        email,
+        roles,
+      );
+
+      // Then
+      expect(profileData).toBeDefined();
+    }).toPass();
+  });
+
+  await test.step("TC24.2 - profile should be updated", async () => {
+    // Given
+    const firstName = faker.person.firstName();
+    const middleName = faker.person.firstName();
+    const lastName = faker.person.lastName();
+
+    const email = registeredUser.email;
+    const password = registeredUser.password;
+    const token: Token = await loginApi(apiContext, { login: email, password });
+    const context = buildContextStorage(baseURL, token);
+    const page = await browser.newPage({ storageState: context });
+
+    await openProfilePage(page);
+
+    // When
+    await clickEditProfile(page);
+    await fillProfileDetails(page, {
+      firstName,
+      middleName,
+      lastName,
+    });
+    await page.getByRole("button", { name: "Save" }).click();
+
+    // Then
+    await expect(async () => {
+      await Promise.all([
+        await expect(
+          page.locator("section").getByText(firstName, { exact: true }),
+        ).toBeVisible(),
+        await expect(page.getByText(middleName, { exact: true })).toBeVisible(),
+        await expect(page.getByText(lastName, { exact: true })).toBeVisible(),
+      ]);
+    }).toPass();
+  });
+});
+
+test("TC25 - should show error, when request fails", async ({ adminPage }) => {
+  // Given
+  const errorMessage = "Bad profile update request";
+  await adminPage.route("**/profiles/me", async (route) => {
+    if (route.request().method() === "PUT") {
+      await route.fulfill({
+        status: 400,
+        contentType: "application/json",
+        body: JSON.stringify({
+          code: "Bad Request",
+          message: errorMessage,
+        }),
+      });
+    } else {
+      await route.continue();
+    }
+  });
+
+  await openProfilePage(adminPage);
+
+  // When
+  await clickEditProfile(adminPage);
+  await clickSaveProfile(adminPage);
+  const errorMessageElement = adminPage.getByText(
+    new RegExp(`^${errorMessage}$`),
+  );
+
+  // Then
+  await expect(errorMessageElement).toBeVisible();
 });

--- a/uitests/tests/profile/profiles.utils.ts
+++ b/uitests/tests/profile/profiles.utils.ts
@@ -1,7 +1,34 @@
 import { Page } from "playwright";
 
+interface UpdateProfileType {
+  firstName: string;
+  middleName?: string;
+  lastName: string;
+}
+
 export const navigateToProfile = async (page: Page, email: string) => {
   const avatarLetter = email.charAt(0).toUpperCase();
   await page.getByRole("button", { name: avatarLetter, exact: true }).click();
   await page.getByRole("menuitem", { name: "Profile" }).click();
+};
+
+export const clickEditProfile = async (page: Page) => {
+  await page.getByRole("button", { name: "Edit profile" }).click();
+};
+
+export const clickSaveProfile = async (page: Page) => {
+  await page.getByRole("button", { name: "Save changes" }).click();
+};
+
+export const fillProfileDetails = async (
+  page: Page,
+  profile: UpdateProfileType,
+) => {
+  await page
+    .getByRole("textbox", { name: "first name" })
+    .fill(profile.firstName);
+  await page
+    .getByRole("textbox", { name: "middle name" })
+    .fill(profile.middleName ?? "");
+  await page.getByRole("textbox", { name: "last name" }).fill(profile.lastName);
 };


### PR DESCRIPTION
Added profile update possibility to the profile service.

Added profile update publisher and subscriber to the Profile Service. Included PUT /profiles/me endpoint to update currently logged in user profile.

Added PUT /qa/profiles request that allow for testing of profile update service listener without Rabbit.

Updated API tests and UI tests to include testing profile update.