### PR TITLE
[FE] Add roles display to Profile page

### DIFF
--- a/frontend/src/components/admin/roles-update/roles-list/RolesList.tsx
+++ b/frontend/src/components/admin/roles-update/roles-list/RolesList.tsx
@@ -1,15 +1,7 @@
-import { Badge, BadgeProps, Button, Flex, Heading } from '@radix-ui/themes';
+import { Badge, Button, Flex, Heading } from '@radix-ui/themes';
 import { RoleType } from '../../../../types/api/RoleTypes.ts';
 import { ReactNode } from 'react';
-
-const colorMap: Record<string, BadgeProps['color']> = {
-  OPERATOR: 'gray',
-  DESIGNER: 'blue',
-  ADMIN: 'crimson',
-};
-
-const getColor = (role: RoleType): BadgeProps['color'] =>
-  colorMap[role.name] ?? 'violet';
+import { getColor } from '../../../../types/components/RoleTypes.ts';
 
 interface RolesListProps {
   title: string;

--- a/frontend/src/components/icons/PersonGearOutlineIcon.tsx
+++ b/frontend/src/components/icons/PersonGearOutlineIcon.tsx
@@ -1,0 +1,31 @@
+import BaseIcon from './base/BaseIcon.tsx';
+import { IconProps } from '../../types/components/BaseTypes.ts';
+
+const PersonGearOutlineIcon = ({ className }: IconProps) => {
+  return (
+    <BaseIcon className={className}>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={2}
+        strokeLinecap="square"
+      >
+        <path d="m14.305 19.53.923-.382" />
+        <path d="m15.228 16.852-.923-.383" />
+        <path d="m16.852 15.228-.383-.923" />
+        <path d="m16.852 20.772-.383.924" />
+        <path d="m19.148 15.228.383-.923" />
+        <path d="m19.53 21.696-.382-.924" />
+        <path d="M2 21a8 8 0 0 1 10.434-7.62" />
+        <path d="m20.772 16.852.924-.383" />
+        <path d="m20.772 19.148.924.383" />
+        <circle cx="10" cy="8" r="5" />
+        <circle cx="18" cy="18" r="3" />
+      </svg>
+    </BaseIcon>
+  );
+};
+
+export default PersonGearOutlineIcon;

--- a/frontend/src/components/profile/Profile.tsx
+++ b/frontend/src/components/profile/Profile.tsx
@@ -1,11 +1,13 @@
 import {
   Avatar,
+  Badge,
   Box,
   Flex,
   Grid,
   Heading,
   Link,
   Separator,
+  Skeleton,
 } from '@radix-ui/themes';
 import {
   useMyProfileQuery,
@@ -17,9 +19,15 @@ import { FormEvent, useState } from 'react';
 import Form from '../shared/form/Form.tsx';
 import ProfileControls from './ProfileControls.tsx';
 import { UpdateProfileType } from '../../types/api/ProfileTypes.ts';
+import { useMeData } from '../../hooks/useMeData.tsx';
+import { getColor } from '../../types/components/RoleTypes.ts';
+import { EnvelopeClosedIcon, PersonIcon } from '@radix-ui/react-icons';
+import PersonGearOutlineIcon from '../icons/PersonGearOutlineIcon.tsx';
 
 const Profile = () => {
   const { data: profileData } = useMyProfileQuery();
+  const { me } = useMeData();
+
   const [isEdited, setIsEdited] = useState(false);
   const [updateProfile] = useUpdateMyProfileMutation();
 
@@ -70,7 +78,7 @@ const Profile = () => {
           gap="4"
           align="start"
         >
-          <ProfileSection title="Personal Information">
+          <ProfileSection title="Personal Information" icon={PersonIcon}>
             <Grid columns="2" gap="4" minHeight="0">
               <ProfileItem
                 isEdited={isEdited}
@@ -99,13 +107,28 @@ const Profile = () => {
               </Box>
             </Grid>
           </ProfileSection>
-          <ProfileSection title="email address">
+          <ProfileSection title="email address" icon={EnvelopeClosedIcon}>
             <ProfileItem isEdited={false} isLoading={!profileData}>
               <Link href={`mailto:${profileData?.email}`}>
                 {profileData?.email ?? ''}
               </Link>
             </ProfileItem>
           </ProfileSection>
+          <Box gridColumnStart="1" gridColumnEnd="3">
+            <ProfileSection title="Assigned Roles" icon={PersonGearOutlineIcon}>
+              <Flex direction="row" justify="start" align="center" gap="2">
+                <Skeleton loading={!me}>
+                  {me?.roles
+                    .toSorted((a, b) => b.id - a.id)
+                    .map((role) => (
+                      <Badge key={role.name} size="3" color={getColor(role)}>
+                        {role.name}
+                      </Badge>
+                    ))}
+                </Skeleton>
+              </Flex>
+            </ProfileSection>
+          </Box>
 
           <ProfileControls
             isEdited={isEdited}

--- a/frontend/src/components/profile/ProfileSection.tsx
+++ b/frontend/src/components/profile/ProfileSection.tsx
@@ -1,20 +1,22 @@
 import { Box, Card, DataList, Flex, Heading } from '@radix-ui/themes';
-import { PersonIcon } from '@radix-ui/react-icons';
 import { PropsWithChildren } from 'react';
+import { IconType } from '../../types/components/BaseTypes.ts';
 
 interface ProfileSectionProps {
   title: string;
+  icon: IconType;
 }
 
 const ProfileSection = ({
   title,
+  icon: Icon,
   children,
 }: PropsWithChildren<ProfileSectionProps>) => {
   return (
     <Card>
       <Box p="2">
         <Flex direction="row" justify="start" align="center" gap="2">
-          <PersonIcon className="size-(--font-size-4) text-(--accent-11)" />
+          <Icon className="size-(--font-size-4) text-(--accent-11)" />
           <Heading as="h3" size="2" weight="medium" trim="both">
             {title}
           </Heading>

--- a/frontend/src/types/components/RoleTypes.ts
+++ b/frontend/src/types/components/RoleTypes.ts
@@ -1,0 +1,11 @@
+import { BadgeProps } from '@radix-ui/themes';
+import { RoleType } from '../api/RoleTypes.ts';
+
+export const colorMap: Record<string, BadgeProps['color']> = {
+  OPERATOR: 'gray',
+  DESIGNER: 'blue',
+  ADMIN: 'crimson',
+};
+
+export const getColor = (role: RoleType): BadgeProps['color'] =>
+  colorMap[role.name] ?? 'violet';

--- a/frontend/tests/components/profile/Profile.test.tsx
+++ b/frontend/tests/components/profile/Profile.test.tsx
@@ -1,16 +1,30 @@
 import * as profileApiModule from '../../../src/store/api/profile.ts';
+import * as useMeDataModule from '../../../src/hooks/useMeData.tsx';
 import { afterEach, beforeEach, describe, expect } from 'vitest';
 import { ProfileType, UpdateProfileType, } from '../../../src/types/api/ProfileTypes.ts';
 import { renderWithProviders } from '../../test-utils.tsx';
 import { fireEvent, screen } from '@testing-library/react';
 import Profile from '../../../src/components/profile/Profile.tsx';
 import { UserEvent, userEvent } from '@testing-library/user-event';
+import { MeType } from '../../../src/store/api/auth.ts';
+import { RoleType } from '../../../src/types/api/RoleTypes.ts';
 
+const email = 'test@test.com';
 const profileData: ProfileType = {
   firstName: 'John',
   middleName: 'Jack',
   lastName: 'Doe',
-  email: 'test@test.com',
+  email,
+};
+const roles: RoleType[] = [
+  {
+    id: 1,
+    name: 'OPERATOR',
+  },
+];
+const meData: MeType = {
+  email,
+  roles,
 };
 
 describe('Profile', () => {
@@ -26,6 +40,11 @@ describe('Profile', () => {
       isError: false,
       data: profileData,
       refetch: vi.fn(),
+    });
+    vi.spyOn(useMeDataModule, 'useMeData').mockReturnValue({
+      me: meData,
+      isLoading: false,
+      isError: false,
     });
     vi.spyOn(profileApiModule, 'useUpdateMyProfileMutation').mockReturnValue([
       mockProfileUpdate,
@@ -91,11 +110,30 @@ describe('Profile', () => {
     // Given
     renderWithProviders(<Profile />);
 
-    // when
+    // When
     const emailElement = screen.getByText(profileData.email);
 
     // Then
     expect(emailElement).toBeInTheDocument();
+  });
+
+  it('Should render roles', () => {
+    // Given
+    const rolesTitle = 'Assigned Roles';
+    renderWithProviders(<Profile />);
+
+    // When
+    const titleElement = screen.getByRole('heading', { name: rolesTitle });
+    const roleElements = meData.roles.map((role) =>
+      screen.getByText(role.name)
+    );
+
+    // Then
+    expect(titleElement).toBeInTheDocument();
+    expect(roleElements).toHaveLength(meData.roles.length);
+    roleElements.forEach((element) => {
+      expect(element).toBeInTheDocument();
+    });
   });
 
   describe('Editability', () => {

--- a/frontend/tests/components/profile/ProfileSection.test.tsx
+++ b/frontend/tests/components/profile/ProfileSection.test.tsx
@@ -1,12 +1,13 @@
 import ProfileSection from '../../../src/components/profile/ProfileSection.tsx';
 import { render, screen } from '@testing-library/react';
+import { PersonIcon } from '@radix-ui/react-icons';
 
 describe('ProfileSection', () => {
   const title = 'Test Title';
 
   it('Should render title', () => {
     // Given
-    render(<ProfileSection title={title} />);
+    render(<ProfileSection title={title} icon={PersonIcon} />);
 
     // When
     const titleElement = screen.getByRole('heading', { name: title });
@@ -18,7 +19,11 @@ describe('ProfileSection', () => {
   it('Should render children', () => {
     // Given
     const children = 'Test children';
-    render(<ProfileSection title={title}>{children}</ProfileSection>);
+    render(
+      <ProfileSection title={title} icon={PersonIcon}>
+        {children}
+      </ProfileSection>
+    );
 
     // When
     const childrenElement = screen.getByText(children);


### PR DESCRIPTION
Added display of user assigned roles on the Profile Page. The roles will have the similar color and style as badges in the update roles in admin page (shared styles).

It uses useMeData and renders skeleton if the data is not yet available.