### PR TITLE
[BE] Image upload endpoint PUT /profiles/me/image

### DIFF
--- a/backend/api-gateway-service/src/main/resources/application.yaml
+++ b/backend/api-gateway-service/src/main/resources/application.yaml
@@ -21,6 +21,15 @@ frontend:
 spring:
   application:
     name: api-gateway-service
+  servlet:
+    multipart:
+      max-request-size: 10MB
+      max-file-size: 10MB
+  webflux:
+    multipart:
+      max-in-memory-size: 1MB
+      max-disk-usage-per-part: 10MB
+      max-parts: 128
   cloud:
     gateway:
       server:
@@ -52,6 +61,15 @@ spring:
                 - Path=/api/profile/**
                 - Method=GET,PUT
                 - Header=Content-Type, application/json
+              filters:
+                - AddRequestHeader=X-Gateway, api-gateway-service
+                - RewritePath=/api/profile/?(?<segment>.*), /$\{segment}
+            - id: profile-service-file-upload
+              uri: lb://profile-service
+              predicates:
+                - Path=/api/profile/**
+                - Method=POST
+                - Header=Content-Type, multipart/form-data.*
               filters:
                 - AddRequestHeader=X-Gateway, api-gateway-service
                 - RewritePath=/api/profile/?(?<segment>.*), /$\{segment}

--- a/backend/api-gateway-service/src/test/java/org/maxq/apigatewayservice/config/ServiceLoadBalancerConfig.java
+++ b/backend/api-gateway-service/src/test/java/org/maxq/apigatewayservice/config/ServiceLoadBalancerConfig.java
@@ -39,8 +39,8 @@ public class ServiceLoadBalancerConfig {
     public ServiceInstanceListSupplier profileServiceInstanceListSupplier(Environment env) {
       return ServiceInstanceListSuppliers.from("test-load-balancer",
           new DefaultServiceInstance(
-              "authorization-service-1",
-              "authorization-service",
+              "profile-service-1",
+              "profile-service",
               "localhost", 8082, false
           )
       );

--- a/backend/api-gateway-service/src/test/java/org/maxq/apigatewayservice/route/routing/ProfileServiceFileUploadRoutingTest.java
+++ b/backend/api-gateway-service/src/test/java/org/maxq/apigatewayservice/route/routing/ProfileServiceFileUploadRoutingTest.java
@@ -1,0 +1,85 @@
+package org.maxq.apigatewayservice.route.routing;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.maxq.apigatewayservice.config.ServiceLoadBalancerConfig;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+import java.time.Duration;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+
+@SpringBootTest(
+    classes = {ServiceLoadBalancerConfig.class},
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
+)
+@WireMockTest(httpPort = 8082)
+@TestPropertySource(properties = {
+    "eureka.client.enabled=false",
+    "test.loadbalancer=profile"
+})
+class ProfileServiceFileUploadRoutingTest {
+
+  private static final String PROFILE_URL = "/api/profile";
+  private static final String UPLOAD_URL = "/test";
+  private static final String BOUNDARY = "CustomBoundaryValue";
+
+  @LocalServerPort
+  private int port;
+  @Autowired
+  private WebTestClient webTestClient;
+
+  @BeforeEach
+  void setUp() {
+    String baseUri = "http://localhost:" + port;
+    this.webTestClient =
+        WebTestClient.bindToServer()
+            .responseTimeout(Duration.ofSeconds(10))
+            .baseUrl(baseUri)
+            .build();
+
+    stubFor(WireMock.request(HttpMethod.POST.name(), WireMock.urlEqualTo(UPLOAD_URL))
+        .willReturn(WireMock.ok()));
+  }
+
+  @Test
+  void shouldCallDownstreamService() {
+    // Given
+
+    // When
+    webTestClient.post()
+        .uri(PROFILE_URL + UPLOAD_URL)
+        .header(HttpHeaders.CONTENT_TYPE, MediaType.MULTIPART_FORM_DATA_VALUE + ";boundary=" + BOUNDARY)
+        .exchange()
+        .expectStatus().isOk();
+
+    // Then
+    verify(1, WireMock.postRequestedFor(WireMock.urlEqualTo("/test")));
+  }
+
+  @Test
+  void shouldAddXGatewayHeader() {
+    // Given
+
+    // When
+    webTestClient.post()
+        .uri(PROFILE_URL + UPLOAD_URL)
+        .header(HttpHeaders.CONTENT_TYPE, MediaType.MULTIPART_FORM_DATA_VALUE + ";boundary=" + BOUNDARY)
+        .exchange()
+        .expectStatus().isOk();
+
+    // Then
+    verify(WireMock.postRequestedFor(WireMock.urlEqualTo("/test"))
+        .withHeader("X-Gateway", WireMock.equalTo("api-gateway-service")));
+  }
+}

--- a/backend/profile-service/src/main/java/org/maxq/profileservice/config/controller/GlobalHttpErrorHandler.java
+++ b/backend/profile-service/src/main/java/org/maxq/profileservice/config/controller/GlobalHttpErrorHandler.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.multipart.support.MissingServletRequestPartException;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 @Slf4j
@@ -48,5 +49,9 @@ public class GlobalHttpErrorHandler extends ResponseEntityExceptionHandler {
     return new ResponseEntity<>(new HttpErrorMessage(message), HttpStatus.METHOD_NOT_ALLOWED);
   }
 
-
+  @Override
+  protected ResponseEntity<Object> handleMissingServletRequestPart(MissingServletRequestPartException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+    log.error(ex.getMessage(), ex);
+    return new ResponseEntity<>(new HttpErrorMessage(ex.getMessage()), HttpStatus.BAD_REQUEST);
+  }
 }

--- a/backend/profile-service/src/main/java/org/maxq/profileservice/controller/ProfileController.java
+++ b/backend/profile-service/src/main/java/org/maxq/profileservice/controller/ProfileController.java
@@ -2,6 +2,7 @@ package org.maxq.profileservice.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.maxq.profileservice.controller.api.ProfileApi;
 import org.maxq.profileservice.domain.Profile;
 import org.maxq.profileservice.domain.dto.ProfileDto;
@@ -16,7 +17,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
+@Slf4j
 @RestController
 @RequestMapping("/profiles")
 @RequiredArgsConstructor
@@ -50,6 +53,16 @@ public class ProfileController implements ProfileApi {
     RabbitmqMessage<ProfileDto> message = new RabbitmqMessage<>(profileDtoToSave, updateProfileTopic);
 
     messageService.sendMessage(message);
+    return ResponseEntity.ok().build();
+  }
+
+  @Override
+  @PostMapping("/me/image")
+  @PreAuthorize("authentication.principal != null")
+  public ResponseEntity<Void> updateProfileImage(Authentication authentication,
+                                                 @RequestParam("file") MultipartFile file) {
+    log.info("Updating profile image for user: {}", authentication.getPrincipal());
+    log.info("Received file: {}", file.getOriginalFilename());
     return ResponseEntity.ok().build();
   }
 }

--- a/backend/profile-service/src/main/java/org/maxq/profileservice/controller/api/ProfileApi.java
+++ b/backend/profile-service/src/main/java/org/maxq/profileservice/controller/api/ProfileApi.java
@@ -11,6 +11,7 @@ import org.maxq.profileservice.domain.dto.UpdateProfileDto;
 import org.maxq.profileservice.domain.exception.ElementNotFoundException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "Profiles API")
 public interface ProfileApi {
@@ -66,4 +67,26 @@ public interface ProfileApi {
       })
   ResponseEntity<Void> updateProfile(Authentication authentication, UpdateProfileDto profileDto)
       throws ElementNotFoundException;
+
+  @Operation(
+      summary = "Update profile image",
+      description = "Allows to update profile image"
+  )
+  @ApiResponse(responseCode = "200", description = "Image update message properly sent")
+  @ApiResponse(responseCode = "400",
+      description = "Bad Request - file validation failed or no file provided",
+      content = {
+          @Content(mediaType = "application/json", schema = @Schema(implementation = HttpErrorMessage.class))
+      })
+  @ApiResponse(responseCode = "401",
+      description = "Unauthenticated - only request with Robot Token are passed",
+      content = {
+          @Content(mediaType = "application/json", schema = @Schema(implementation = HttpErrorMessage.class))
+      })
+  @ApiResponse(responseCode = "403",
+      description = "Unauthorized - only logged in users can access this resource",
+      content = {
+          @Content(mediaType = "application/json", schema = @Schema(implementation = HttpErrorMessage.class))
+      })
+  ResponseEntity<Void> updateProfileImage(Authentication authentication, MultipartFile file);
 }

--- a/backend/profile-service/src/main/resources/application.yml
+++ b/backend/profile-service/src/main/resources/application.yml
@@ -1,5 +1,7 @@
 server:
   port: ${PORT:8082}
+  tomcat:
+    max-http-form-post-size: 11MB
 
 eureka:
   client:
@@ -24,6 +26,13 @@ profile:
 spring:
   application:
     name: profile-service
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 11MB
+      file-size-threshold: 1MB
+      enabled: true
+      location: ${java.io.tmpdir}
   datasource:
     password: ${PROFILE_POSTGRES_PASS:password}
     url: ${PROFILE_POSTGRES_LINK:jdbc:postgresql://localhost:5433/profile-db?sslmode=disable}

--- a/frontend/src/components/profile/Profile.tsx
+++ b/frontend/src/components/profile/Profile.tsx
@@ -10,6 +10,7 @@ import {
 } from '@radix-ui/themes';
 import {
   useMyProfileQuery,
+  useUpdateMyProfileImageMutation,
   useUpdateMyProfileMutation,
 } from '../../store/api/profile.ts';
 import ProfileSection from './ProfileSection.tsx';
@@ -32,6 +33,7 @@ const Profile = () => {
   const [isEdited, setIsEdited] = useState(false);
   const imageUpload = useImageUpload();
   const [updateProfile] = useUpdateMyProfileMutation();
+  const [updateProfileImage] = useUpdateMyProfileImageMutation();
 
   const handleEdit = () => {
     setIsEdited(true);
@@ -45,6 +47,7 @@ const Profile = () => {
 
     const fd = new FormData(event.currentTarget);
     const data = Object.fromEntries(fd.entries());
+    const image = imageUpload.selectedFile;
 
     const profile: UpdateProfileType = {
       firstName: data['first name'] as string,
@@ -52,6 +55,14 @@ const Profile = () => {
       lastName: data['last name'] as string,
     };
     void updateProfile(profile);
+
+    if (image) {
+      const formData = new FormData();
+      formData.append('file', image.file);
+      void updateProfileImage(formData);
+    }
+
+    handleCancel();
     setIsEdited(false);
   };
 

--- a/frontend/src/store/api/profile.ts
+++ b/frontend/src/store/api/profile.ts
@@ -1,11 +1,11 @@
 /* eslint-disable @typescript-eslint/no-invalid-void-type */
-import { profileApi as PROFILE_API } from './base.ts';
-import { api } from '../apiSlice.ts';
-import { ProfileType, UpdateProfileType, } from '../../types/api/ProfileTypes.ts';
-import { readErrorMessage } from '../../utils/errorUtils.ts';
-import { registerModal } from '../modalSlice.ts';
-import { v4 as uuidv4 } from 'uuid';
-import { getStringOrDefault } from '../../utils/shared.ts';
+import {profileApi as PROFILE_API} from './base.ts';
+import {api} from '../apiSlice.ts';
+import {ProfileType, UpdateProfileType,} from '../../types/api/ProfileTypes.ts';
+import {readErrorMessage} from '../../utils/errorUtils.ts';
+import {registerModal} from '../modalSlice.ts';
+import {v4 as uuidv4} from 'uuid';
+import {getStringOrDefault} from '../../utils/shared.ts';
 
 const PROFILES_API = '/profiles';
 const HEALTHCHECK_API = '/actuator/health';
@@ -68,6 +68,18 @@ export const profileApi = api.injectEndpoints({
         }
       },
     }),
+    updateMyProfileImage: builder.mutation<undefined, FormData>({
+      query: (formData) => {
+        return {
+          url: PROFILE_API + PROFILES_API + '/me/image',
+          method: 'POST',
+          headers: {
+            'Content-Type': undefined,
+          },
+          body: formData,
+        };
+      },
+    }),
   }),
 });
 
@@ -75,4 +87,5 @@ export const {
   useProfileHealthcheckQuery,
   useMyProfileQuery,
   useUpdateMyProfileMutation,
+  useUpdateMyProfileImageMutation,
 } = profileApi;

--- a/frontend/tests/store/api/profile.test.tsx
+++ b/frontend/tests/store/api/profile.test.tsx
@@ -9,6 +9,7 @@ import { act, PropsWithChildren } from 'react';
 import {
   useMyProfileQuery,
   useProfileHealthcheckQuery,
+  useUpdateMyProfileImageMutation,
   useUpdateMyProfileMutation,
 } from '../../../src/store/api/profile.ts';
 import { setupStore } from '../../../src/store';
@@ -461,6 +462,165 @@ describe('Profiles API', () => {
       await waitFor(() => {
         const currentResult = result.current as ReturnType<
           typeof useUpdateMyProfileMutation
+        >;
+        const [, { isSuccess, isLoading, isError, error }] = currentResult;
+        expect(isSuccess).toBe(false);
+        expect(isLoading).toBe(false);
+        expect(isError).toBe(true);
+        expect(error).toBeDefined();
+        expect((error as CustomFetchBaseQueryError).status).toStrictEqual(500);
+        expect((error as CustomFetchBaseQueryError).message).toStrictEqual(
+          errorMessage
+        );
+      });
+    });
+  });
+
+  describe('useUpdateMyProfileImageMutation', () => {
+    let formData: FormData;
+    const file = new File(['test'], 'test.txt', { type: 'image/jpg' });
+
+    beforeEach(() => {
+      formData = new FormData();
+      formData.append('file', file);
+    });
+
+    it('Should make API call with correct parameters', async () => {
+      // Given
+      vi.mocked(customBaseQuery).mockResolvedValue({
+        data: undefined,
+      });
+
+      const { result } = renderHookWithProviders(() =>
+        useUpdateMyProfileImageMutation()
+      );
+
+      // When
+      const currentResult = result.current as ReturnType<
+        typeof useUpdateMyProfileImageMutation
+      >;
+      const [uploadImage] = currentResult;
+      act(() => {
+        void uploadImage(formData);
+      });
+
+      // Then
+      await waitFor(() => {
+        expect(customBaseQuery).toHaveBeenCalledOnce();
+        expect(customBaseQuery).toHaveBeenCalledWith(
+          {
+            url: `/profile/profiles/me/image`,
+            method: 'POST',
+            headers: {
+              'Content-Type': undefined,
+            },
+            body: formData,
+          },
+          expect.any(Object),
+          undefined
+        );
+      });
+    });
+
+    it('Should return success state', async () => {
+      // Given
+      vi.mocked(customBaseQuery).mockResolvedValue({
+        data: undefined,
+      });
+
+      const { result } = renderHookWithProviders(() =>
+        useUpdateMyProfileImageMutation()
+      );
+
+      // When
+      const currentResult = result.current as ReturnType<
+        typeof useUpdateMyProfileImageMutation
+      >;
+      const [uploadImage] = currentResult;
+      act(() => {
+        void uploadImage(formData);
+      });
+
+      // Then
+      await waitFor(() => {
+        const currentResult = result.current as ReturnType<
+          typeof useUpdateMyProfileImageMutation
+        >;
+        const [, { isSuccess, isLoading, isError, error }] = currentResult;
+        expect(isSuccess).toBe(true);
+        expect(isLoading).toBe(false);
+        expect(isError).toBe(false);
+        expect(error).toBe(undefined);
+      });
+    });
+
+    it('Should handle loading state', async () => {
+      // Given
+      let resolvePromise: (value: { data: undefined }) => void;
+      const controlledPromise = new Promise<{ data: undefined }>((resolve) => {
+        resolvePromise = resolve;
+      });
+
+      vi.mocked(customBaseQuery).mockReturnValue(controlledPromise);
+
+      const { result } = renderHookWithProviders(() =>
+        useUpdateMyProfileImageMutation()
+      );
+
+      // When
+      const currentResult = result.current as ReturnType<
+        typeof useUpdateMyProfileImageMutation
+      >;
+      const [uploadImage] = currentResult;
+      act(() => {
+        void uploadImage(formData);
+      });
+
+      // Then
+      await waitFor(() => {
+        const currentResult = result.current as ReturnType<
+          typeof useUpdateMyProfileImageMutation
+        >;
+        const [, { isSuccess, isLoading, isError, error }] = currentResult;
+        expect(isSuccess).toBe(false);
+        expect(isLoading).toBe(true);
+        expect(isError).toBe(false);
+        expect(error).toBe(undefined);
+      });
+
+      // Clean up - resolve the promise to avoid hanging
+      act(() => {
+        resolvePromise({ data: undefined });
+      });
+    });
+
+    it('Should handle error state', async () => {
+      // Given
+      const errorMessage = 'Error while fetching roles data';
+      vi.mocked(customBaseQuery).mockResolvedValue({
+        error: {
+          status: 500,
+          message: errorMessage,
+        },
+      });
+
+      const { result } = renderHookWithProviders(() =>
+        useUpdateMyProfileImageMutation()
+      );
+
+      // When
+      const currentResult = result.current as ReturnType<
+        typeof useUpdateMyProfileImageMutation
+      >;
+      const [uploadImage] = currentResult;
+      act(() => {
+        void uploadImage(formData);
+      });
+
+      // Then
+      await waitFor(() => {
+        const currentResult = result.current as ReturnType<
+          typeof useUpdateMyProfileImageMutation
         >;
         const [, { isSuccess, isLoading, isError, error }] = currentResult;
         expect(isSuccess).toBe(false);


### PR DESCRIPTION
Added request routing through API gateway to profile picture upload endpoint. 

Added POST /profiles/me/image endpoint for uploading image updates - for now it does nothing, but will be enhanced in future efforts.

Added update profile image mutation to frontend that is triggered during profile update.