### PR TITLE
[BE] Image processing and sanitization

### DIFF
--- a/backend/profile-service/src/main/java/org/maxq/profileservice/config/image/ImageServiceConfig.java
+++ b/backend/profile-service/src/main/java/org/maxq/profileservice/config/image/ImageServiceConfig.java
@@ -6,6 +6,9 @@ import org.apache.commons.imaging.formats.jpeg.xmp.JpegXmpRewriter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import javax.imageio.ImageIO;
+import javax.imageio.ImageWriter;
+
 @Configuration
 public class ImageServiceConfig {
 
@@ -22,5 +25,10 @@ public class ImageServiceConfig {
   @Bean
   public JpegIptcRewriter jpegIptcRewriter() {
     return new JpegIptcRewriter();
+  }
+
+  @Bean
+  public ImageWriter jpegImageWriter() {
+    return ImageIO.getImageWritersByFormatName("jpeg").next();
   }
 }

--- a/backend/profile-service/src/main/java/org/maxq/profileservice/config/image/ImageServiceConfig.java
+++ b/backend/profile-service/src/main/java/org/maxq/profileservice/config/image/ImageServiceConfig.java
@@ -1,0 +1,26 @@
+package org.maxq.profileservice.config.image;
+
+import org.apache.commons.imaging.formats.jpeg.exif.ExifRewriter;
+import org.apache.commons.imaging.formats.jpeg.iptc.JpegIptcRewriter;
+import org.apache.commons.imaging.formats.jpeg.xmp.JpegXmpRewriter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ImageServiceConfig {
+
+  @Bean
+  public ExifRewriter exifRewriter() {
+    return new ExifRewriter();
+  }
+
+  @Bean
+  public JpegXmpRewriter jpegXmpRewriter() {
+    return new JpegXmpRewriter();
+  }
+
+  @Bean
+  public JpegIptcRewriter jpegIptcRewriter() {
+    return new JpegIptcRewriter();
+  }
+}

--- a/backend/profile-service/src/main/java/org/maxq/profileservice/domain/ImageMetadata.java
+++ b/backend/profile-service/src/main/java/org/maxq/profileservice/domain/ImageMetadata.java
@@ -2,9 +2,11 @@ package org.maxq.profileservice.domain;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.ToString;
 
 @Getter
 @RequiredArgsConstructor
+@ToString
 public class ImageMetadata {
 
   private final ImageSize size;

--- a/backend/profile-service/src/main/java/org/maxq/profileservice/domain/InMemoryFile.java
+++ b/backend/profile-service/src/main/java/org/maxq/profileservice/domain/InMemoryFile.java
@@ -3,6 +3,7 @@ package org.maxq.profileservice.domain;
 import jakarta.annotation.Nullable;
 import lombok.Getter;
 
+import java.util.Arrays;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -14,10 +15,10 @@ public final class InMemoryFile {
   private final String contentType;
   private final byte[] data;
 
-  private InMemoryFile(String contentType, String name, byte[] data) {
+  public InMemoryFile(String contentType, String name, byte[] data) {
     this.contentType = contentType;
     this.name = name;
-    this.data = data;
+    this.data = Arrays.copyOf(data, data.length);
   }
 
   public static InMemoryFile create(byte[] data, @Nullable String contentType) {

--- a/backend/profile-service/src/main/java/org/maxq/profileservice/mapper/InMemoryFileMapper.java
+++ b/backend/profile-service/src/main/java/org/maxq/profileservice/mapper/InMemoryFileMapper.java
@@ -10,4 +10,8 @@ public class InMemoryFileMapper {
   public ImageDto mapToImageDto(InMemoryFile file, String userEmail) {
     return new ImageDto(userEmail, file.getName(), file.getContentType(), file.getData());
   }
+
+  public InMemoryFile mapToInMemoryFile(ImageDto imageDto) {
+    return new InMemoryFile(imageDto.getContentType(), imageDto.getName(), imageDto.getData());
+  }
 }

--- a/backend/profile-service/src/main/java/org/maxq/profileservice/service/image/ApacheImageService.java
+++ b/backend/profile-service/src/main/java/org/maxq/profileservice/service/image/ApacheImageService.java
@@ -1,5 +1,6 @@
 package org.maxq.profileservice.service.image;
 
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.imaging.AbstractImageParser;
 import org.apache.commons.imaging.ImageFormat;
@@ -7,14 +8,19 @@ import org.apache.commons.imaging.Imaging;
 import org.apache.commons.imaging.ImagingException;
 import org.apache.commons.imaging.formats.jpeg.JpegImageMetadata;
 import org.apache.commons.imaging.formats.jpeg.JpegImageParser;
+import org.apache.commons.imaging.formats.jpeg.exif.ExifRewriter;
+import org.apache.commons.imaging.formats.jpeg.iptc.JpegIptcRewriter;
+import org.apache.commons.imaging.formats.jpeg.xmp.JpegXmpRewriter;
 import org.apache.commons.imaging.formats.png.PngImageParser;
 import org.apache.commons.imaging.formats.tiff.TiffField;
 import org.apache.commons.imaging.formats.tiff.TiffImageMetadata;
 import org.maxq.profileservice.domain.ImageMetadata;
 import org.maxq.profileservice.domain.ImageSize;
+import org.maxq.profileservice.domain.InMemoryFile;
 import org.springframework.stereotype.Service;
 
 import java.awt.*;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
@@ -22,8 +28,13 @@ import java.util.Optional;
 
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class ApacheImageService implements ImageService {
   private static final int MIN_EXIF_FIELDS = 2; // Expected at least width and height fields
+
+  private final ExifRewriter exifRewriter;
+  private final JpegXmpRewriter jpegXmpRewriter;
+  private final JpegIptcRewriter jpegIptcRewriter;
 
   @Override
   public ImageFormat guessFormat(byte[] imageData) throws IOException {
@@ -76,5 +87,35 @@ public class ApacheImageService implements ImageService {
     return Optional.of(
         new ImageSize(widthField.get().getIntValue(), heightField.get().getIntValue())
     );
+  }
+
+  @Override
+  public InMemoryFile stripMetadata(InMemoryFile file) throws IOException {
+    log.debug("Stripping metadata from file {}", file.getName());
+
+    if ("image/jpeg".equals(file.getContentType()) || "image/jpg".equals(file.getContentType())) {
+      byte[] dataWithoutMeta = stripMetadata(file.getData());
+      return new InMemoryFile(file.getContentType(), file.getName(), dataWithoutMeta);
+    } else {
+      log.info("File is not a JPEG, skipping stripping. Content type: {}", file.getContentType());
+    }
+
+    return file;
+  }
+
+  public byte[] stripMetadata(byte[] data) throws IOException {
+
+    try (ByteArrayOutputStream os = new ByteArrayOutputStream()) {
+      exifRewriter.removeExifMetadata(data, os);
+      byte[] dataWithoutExif = os.toByteArray();
+      os.reset();
+
+      jpegXmpRewriter.removeXmpXml(dataWithoutExif, os);
+      byte[] dataWithoutXmp = os.toByteArray();
+      os.reset();
+
+      jpegIptcRewriter.removeIptc(dataWithoutXmp, os, true);
+      return os.toByteArray();
+    }
   }
 }

--- a/backend/profile-service/src/main/java/org/maxq/profileservice/service/image/ImageService.java
+++ b/backend/profile-service/src/main/java/org/maxq/profileservice/service/image/ImageService.java
@@ -5,7 +5,6 @@ import org.apache.commons.imaging.ImageFormat;
 import org.maxq.profileservice.domain.ImageMetadata;
 import org.maxq.profileservice.domain.InMemoryFile;
 
-import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.util.List;
@@ -20,24 +19,5 @@ public interface ImageService {
 
   ImageMetadata getMetadata(byte[] imageData) throws IOException;
 
-  InMemoryFile stripMetadata(InMemoryFile file) throws IOException;
-
-  BufferedImage resizeImage(InMemoryFile file, int maxWidth, int maxHeight) throws IOException;
-
-  default Dimension calculateDimension(int originalWidth, int originalHeight,
-                                       int maxWidth, int maxHeight) {
-    double oneToOneRatio = 1.0;
-    double widthRatio = (double) maxWidth / originalWidth;
-    double heightRatio = (double) maxHeight / originalHeight;
-    double ratio = Math.min(widthRatio, heightRatio);
-
-    if (ratio >= oneToOneRatio) {
-      return new Dimension(originalWidth, originalHeight);
-    }
-
-    return new Dimension(
-        (int) (originalWidth * ratio),
-        (int) (originalHeight * ratio)
-    );
-  }
+  InMemoryFile writeToJpeg(BufferedImage image) throws IOException;
 }

--- a/backend/profile-service/src/main/java/org/maxq/profileservice/service/image/ImageService.java
+++ b/backend/profile-service/src/main/java/org/maxq/profileservice/service/image/ImageService.java
@@ -5,10 +5,14 @@ import org.apache.commons.imaging.ImageFormat;
 import org.maxq.profileservice.domain.ImageMetadata;
 import org.maxq.profileservice.domain.InMemoryFile;
 
+import java.awt.*;
+import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.util.List;
 
 public interface ImageService {
+  BufferedImage getBufferedImage(InMemoryFile file) throws IOException;
+
   ImageFormat guessFormat(byte[] imageData) throws IOException;
 
   @SuppressWarnings({"java:S1452"})
@@ -17,4 +21,23 @@ public interface ImageService {
   ImageMetadata getMetadata(byte[] imageData) throws IOException;
 
   InMemoryFile stripMetadata(InMemoryFile file) throws IOException;
+
+  BufferedImage resizeImage(InMemoryFile file, int maxWidth, int maxHeight) throws IOException;
+
+  default Dimension calculateDimension(int originalWidth, int originalHeight,
+                                       int maxWidth, int maxHeight) {
+    double oneToOneRatio = 1.0;
+    double widthRatio = (double) maxWidth / originalWidth;
+    double heightRatio = (double) maxHeight / originalHeight;
+    double ratio = Math.min(widthRatio, heightRatio);
+
+    if (ratio >= oneToOneRatio) {
+      return new Dimension(originalWidth, originalHeight);
+    }
+
+    return new Dimension(
+        (int) (originalWidth * ratio),
+        (int) (originalHeight * ratio)
+    );
+  }
 }

--- a/backend/profile-service/src/main/java/org/maxq/profileservice/service/image/ImageService.java
+++ b/backend/profile-service/src/main/java/org/maxq/profileservice/service/image/ImageService.java
@@ -3,6 +3,7 @@ package org.maxq.profileservice.service.image;
 import org.apache.commons.imaging.AbstractImageParser;
 import org.apache.commons.imaging.ImageFormat;
 import org.maxq.profileservice.domain.ImageMetadata;
+import org.maxq.profileservice.domain.InMemoryFile;
 
 import java.io.IOException;
 import java.util.List;
@@ -14,4 +15,6 @@ public interface ImageService {
   List<AbstractImageParser<?>> getParsers();
 
   ImageMetadata getMetadata(byte[] imageData) throws IOException;
+
+  InMemoryFile stripMetadata(InMemoryFile file) throws IOException;
 }

--- a/backend/profile-service/src/main/java/org/maxq/profileservice/service/image/processor/ApacheImageProcessor.java
+++ b/backend/profile-service/src/main/java/org/maxq/profileservice/service/image/processor/ApacheImageProcessor.java
@@ -1,0 +1,88 @@
+package org.maxq.profileservice.service.image.processor;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.imaging.formats.jpeg.exif.ExifRewriter;
+import org.apache.commons.imaging.formats.jpeg.iptc.JpegIptcRewriter;
+import org.apache.commons.imaging.formats.jpeg.xmp.JpegXmpRewriter;
+import org.maxq.profileservice.domain.InMemoryFile;
+import org.maxq.profileservice.service.image.ImageService;
+import org.springframework.stereotype.Service;
+
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ApacheImageProcessor implements ImageProcessor {
+  private static final int MAX_IMAGE_WIDTH = 1024;
+  private static final int MAX_IMAGE_HEIGHT = 1024;
+
+  private final ImageService imageService;
+  private final ExifRewriter exifRewriter;
+  private final JpegXmpRewriter jpegXmpRewriter;
+  private final JpegIptcRewriter jpegIptcRewriter;
+
+  @Override
+  public InMemoryFile stripMetadata(InMemoryFile file) throws IOException {
+    log.debug("Stripping metadata from file {}", file.getName());
+
+    if ("image/jpeg".equals(file.getContentType()) || "image/jpg".equals(file.getContentType())) {
+      byte[] dataWithoutMeta = stripMetadata(file.getData());
+      return new InMemoryFile(file.getContentType(), file.getName(), dataWithoutMeta);
+    } else {
+      log.info("File is not a JPEG, skipping stripping. Content type: {}", file.getContentType());
+    }
+
+    return file;
+  }
+
+  public byte[] stripMetadata(byte[] data) throws IOException {
+    try (ByteArrayOutputStream os = new ByteArrayOutputStream()) {
+      exifRewriter.removeExifMetadata(data, os);
+      byte[] dataWithoutExif = os.toByteArray();
+      os.reset();
+
+      jpegXmpRewriter.removeXmpXml(dataWithoutExif, os);
+      byte[] dataWithoutXmp = os.toByteArray();
+      os.reset();
+
+      jpegIptcRewriter.removeIptc(dataWithoutXmp, os, true);
+      return os.toByteArray();
+    }
+  }
+
+  public BufferedImage resizeImage(InMemoryFile file) throws IOException {
+    return resizeImage(file, MAX_IMAGE_WIDTH, MAX_IMAGE_HEIGHT);
+  }
+
+  @Override
+  public BufferedImage resizeImage(InMemoryFile file, int maxWidth, int maxHeight) throws IOException {
+    BufferedImage originalImage = imageService.getBufferedImage(file);
+    Dimension newDimensions = calculateDimension(originalImage.getWidth(), originalImage.getHeight(), maxWidth, maxHeight);
+    return new BufferedImage(newDimensions.width, newDimensions.height, originalImage.getType());
+  }
+
+  @Override
+  public BufferedImage cleanImage(BufferedImage image) {
+    BufferedImage cleanImage = new BufferedImage(
+        image.getWidth(),
+        image.getHeight(),
+        BufferedImage.TYPE_INT_RGB // Remove an alpha channel of PNG images
+    );
+
+    Graphics2D graphics = cleanImage.createGraphics();
+    graphics.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BILINEAR);
+    graphics.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
+
+    graphics.setColor(Color.WHITE);
+    graphics.fillRect(0, 0, cleanImage.getWidth(), cleanImage.getHeight());
+    graphics.drawImage(image, 0, 0, null);
+    graphics.dispose();
+
+    return cleanImage;
+  }
+}

--- a/backend/profile-service/src/main/java/org/maxq/profileservice/service/image/processor/ImageProcessor.java
+++ b/backend/profile-service/src/main/java/org/maxq/profileservice/service/image/processor/ImageProcessor.java
@@ -1,0 +1,33 @@
+package org.maxq.profileservice.service.image.processor;
+
+import org.maxq.profileservice.domain.InMemoryFile;
+
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+
+public interface ImageProcessor {
+
+  InMemoryFile stripMetadata(InMemoryFile file) throws IOException;
+
+  BufferedImage resizeImage(InMemoryFile file, int maxWidth, int maxHeight) throws IOException;
+
+  BufferedImage cleanImage(BufferedImage image);
+
+  default Dimension calculateDimension(int originalWidth, int originalHeight,
+                                       int maxWidth, int maxHeight) {
+    double oneToOneRatio = 1.0;
+    double widthRatio = (double) maxWidth / originalWidth;
+    double heightRatio = (double) maxHeight / originalHeight;
+    double ratio = Math.min(widthRatio, heightRatio);
+
+    if (ratio >= oneToOneRatio) {
+      return new Dimension(originalWidth, originalHeight);
+    }
+
+    return new Dimension(
+        (int) (originalWidth * ratio),
+        (int) (originalHeight * ratio)
+    );
+  }
+}

--- a/backend/profile-service/src/main/java/org/maxq/profileservice/service/message/handler/ProfileImageUploadHandler.java
+++ b/backend/profile-service/src/main/java/org/maxq/profileservice/service/message/handler/ProfileImageUploadHandler.java
@@ -5,9 +5,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.maxq.profileservice.domain.InMemoryFile;
 import org.maxq.profileservice.domain.dto.ImageDto;
 import org.maxq.profileservice.mapper.InMemoryFileMapper;
-import org.maxq.profileservice.service.image.ImageService;
+import org.maxq.profileservice.service.image.ApacheImageService;
 import org.springframework.stereotype.Component;
 
+import java.awt.image.BufferedImage;
 import java.io.IOException;
 
 @Slf4j
@@ -16,7 +17,7 @@ import java.io.IOException;
 public class ProfileImageUploadHandler implements MessageHandler<ImageDto> {
 
   private final InMemoryFileMapper inMemoryFileMapper;
-  private final ImageService imageService;
+  private final ApacheImageService imageService;
 
   @Override
   public void handleMessage(ImageDto message) {
@@ -26,8 +27,11 @@ public class ProfileImageUploadHandler implements MessageHandler<ImageDto> {
     try {
       InMemoryFile fileWithoutMetadata = imageService.stripMetadata(file);
       log.info("Stripped metadata from file: {}", fileWithoutMetadata.getName());
+
+      BufferedImage resizedImage = imageService.resizeImage(file);
+      log.info("Resized image: {}x{}", resizedImage.getWidth(), resizedImage.getHeight());
     } catch (IOException e) {
-      log.error("Failed to strip metadata from file: {}", file, e);
+      log.error("Failed processing image: {}", file, e);
     }
   }
 }

--- a/backend/profile-service/src/main/java/org/maxq/profileservice/service/message/handler/ProfileImageUploadHandler.java
+++ b/backend/profile-service/src/main/java/org/maxq/profileservice/service/message/handler/ProfileImageUploadHandler.java
@@ -2,16 +2,32 @@ package org.maxq.profileservice.service.message.handler;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.maxq.profileservice.domain.InMemoryFile;
 import org.maxq.profileservice.domain.dto.ImageDto;
+import org.maxq.profileservice.mapper.InMemoryFileMapper;
+import org.maxq.profileservice.service.image.ImageService;
 import org.springframework.stereotype.Component;
+
+import java.io.IOException;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class ProfileImageUploadHandler implements MessageHandler<ImageDto> {
 
+  private final InMemoryFileMapper inMemoryFileMapper;
+  private final ImageService imageService;
+
   @Override
   public void handleMessage(ImageDto message) {
     log.info("Handling message with image: {}", message);
+    InMemoryFile file = inMemoryFileMapper.mapToInMemoryFile(message);
+
+    try {
+      InMemoryFile fileWithoutMetadata = imageService.stripMetadata(file);
+      log.info("Stripped metadata from file: {}", fileWithoutMetadata.getName());
+    } catch (IOException e) {
+      log.error("Failed to strip metadata from file: {}", file, e);
+    }
   }
 }

--- a/backend/profile-service/src/test/java/org/maxq/profileservice/mapper/InMemoryFileMapperTest.java
+++ b/backend/profile-service/src/test/java/org/maxq/profileservice/mapper/InMemoryFileMapperTest.java
@@ -31,4 +31,20 @@ class InMemoryFileMapperTest {
         () -> assertArrayEquals(file.getData(), imageDto.getData(), "Wrong data")
     );
   }
+
+  @Test
+  void shouldMapToInMemoryFile() {
+    // Given
+    ImageDto imageDto = new ImageDto("test@test.com", "test.jpg", "image/jpeg", "test-data".getBytes());
+
+    // When
+    InMemoryFile file = inMemoryFileMapper.mapToInMemoryFile(imageDto);
+
+    // Then
+    assertAll(
+        () -> assertEquals(imageDto.getName(), file.getName(), "Wrong name"),
+        () -> assertEquals(imageDto.getContentType(), file.getContentType(), "Wrong content type"),
+        () -> assertArrayEquals(imageDto.getData(), file.getData(), "Wrong data")
+    );
+  }
 }

--- a/backend/profile-service/src/test/java/org/maxq/profileservice/service/image/ApacheImageServiceTest.java
+++ b/backend/profile-service/src/test/java/org/maxq/profileservice/service/image/ApacheImageServiceTest.java
@@ -58,17 +58,17 @@ class ApacheImageServiceTest {
 
   private List<TiffField> tiffFields;
 
-  private static Stream<TestDimensions> invalidImageDimensions() {
+  private static Stream<DimensionHelper> invalidImageDimensions() {
     return Stream.of(
-        new TestDimensions(
+        new DimensionHelper(
             new Dimension(1025, MAX_RESIZE_DIMENSION),
             new Dimension(MAX_RESIZE_DIMENSION, MAX_RESIZE_DIMENSION)
         ),
-        new TestDimensions(
+        new DimensionHelper(
             new Dimension(MAX_RESIZE_DIMENSION, 1025),
             new Dimension(MAX_RESIZE_DIMENSION, MAX_RESIZE_DIMENSION)
         ),
-        new TestDimensions(
+        new DimensionHelper(
             new Dimension(2 * MAX_RESIZE_DIMENSION, 1025),
             new Dimension(MAX_RESIZE_DIMENSION, MAX_RESIZE_DIMENSION)
         )
@@ -266,16 +266,16 @@ class ApacheImageServiceTest {
 
   @ParameterizedTest
   @MethodSource("invalidImageDimensions")
-  void shouldCalculateDimension_For_BiggerImages(TestDimensions testDimensions) {
+  void shouldCalculateDimension_For_BiggerImages(DimensionHelper dimensionHelper) {
     // Given
-    double expectedRatio = Math.min(testDimensions.widthRatio, testDimensions.heightRatio);
-    int expectedWidth = (int) (testDimensions.inputDimension.width * expectedRatio);
-    int expectedHeight = (int) (testDimensions.inputDimension.height * expectedRatio);
+    double expectedRatio = Math.min(dimensionHelper.widthRatio, dimensionHelper.heightRatio);
+    int expectedWidth = (int) (dimensionHelper.inputDimension.width * expectedRatio);
+    int expectedHeight = (int) (dimensionHelper.inputDimension.height * expectedRatio);
 
-    int biggerWidth = testDimensions.inputDimension.width;
-    int biggerHeight = testDimensions.inputDimension.height;
-    int maxWidth = testDimensions.maxDimension.width;
-    int maxHeight = testDimensions.maxDimension.height;
+    int biggerWidth = dimensionHelper.inputDimension.width;
+    int biggerHeight = dimensionHelper.inputDimension.height;
+    int maxWidth = dimensionHelper.maxDimension.width;
+    int maxHeight = dimensionHelper.maxDimension.height;
 
     // When
     Dimension newDimension
@@ -317,13 +317,13 @@ class ApacheImageServiceTest {
     );
   }
 
-  private static class TestDimensions {
+  private static final class DimensionHelper {
     private final Dimension inputDimension;
     private final Dimension maxDimension;
     private final double widthRatio;
     private final double heightRatio;
 
-    private TestDimensions(Dimension inputDimension, Dimension maxDimension) {
+    private DimensionHelper(Dimension inputDimension, Dimension maxDimension) {
       this.inputDimension = inputDimension;
       this.maxDimension = maxDimension;
       this.widthRatio = (double) maxDimension.width / inputDimension.width;

--- a/backend/profile-service/src/test/java/org/maxq/profileservice/service/image/processor/ApacheImageProcessorTest.java
+++ b/backend/profile-service/src/test/java/org/maxq/profileservice/service/image/processor/ApacheImageProcessorTest.java
@@ -1,0 +1,194 @@
+package org.maxq.profileservice.service.image.processor;
+
+import org.apache.commons.imaging.common.SimpleBufferedImageFactory;
+import org.apache.commons.imaging.formats.jpeg.exif.ExifRewriter;
+import org.apache.commons.imaging.formats.jpeg.iptc.JpegIptcRewriter;
+import org.apache.commons.imaging.formats.jpeg.xmp.JpegXmpRewriter;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.maxq.profileservice.domain.InMemoryFile;
+import org.maxq.profileservice.service.image.ApacheImageService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+class ApacheImageProcessorTest {
+
+  private static final int MAX_RESIZE_DIMENSION = 1024;
+
+  @Autowired
+  private ApacheImageProcessor imageProcessor;
+
+  @MockitoBean
+  private ExifRewriter exifWriter;
+  @MockitoBean
+  private JpegXmpRewriter xmpWriter;
+  @MockitoBean
+  private JpegIptcRewriter iptcWriter;
+  @MockitoBean
+  private ApacheImageService imageService;
+
+
+  private static Stream<DimensionHelper> invalidImageDimensions() {
+    return Stream.of(
+        new DimensionHelper(
+            new Dimension(1025, MAX_RESIZE_DIMENSION),
+            new Dimension(MAX_RESIZE_DIMENSION, MAX_RESIZE_DIMENSION)
+        ),
+        new DimensionHelper(
+            new Dimension(MAX_RESIZE_DIMENSION, 1025),
+            new Dimension(MAX_RESIZE_DIMENSION, MAX_RESIZE_DIMENSION)
+        ),
+        new DimensionHelper(
+            new Dimension(2 * MAX_RESIZE_DIMENSION, 1025),
+            new Dimension(MAX_RESIZE_DIMENSION, MAX_RESIZE_DIMENSION)
+        )
+    );
+  }
+
+  @Test
+  void shouldStrip_When_JpegFile() throws IOException {
+    // Given
+    InMemoryFile file = InMemoryFile.create("test".getBytes(), "image/jpeg");
+    doNothing().when(exifWriter).removeExifMetadata(any(byte[].class), any(ByteArrayOutputStream.class));
+    doNothing().when(xmpWriter).removeXmpXml(any(byte[].class), any(ByteArrayOutputStream.class));
+    doNothing().when(iptcWriter)
+        .removeIptc(any(byte[].class), any(ByteArrayOutputStream.class), anyBoolean());
+
+    // When
+    InMemoryFile strippedFile = imageProcessor.stripMetadata(file);
+
+    // Then
+    verify(exifWriter, times(1))
+        .removeExifMetadata(eq(file.getData()), any(ByteArrayOutputStream.class));
+    verify(xmpWriter, times(1))
+        .removeXmpXml(any(byte[].class), any(ByteArrayOutputStream.class));
+    verify(iptcWriter, times(1))
+        .removeIptc(any(byte[].class), any(ByteArrayOutputStream.class), eq(true));
+    assertNotEquals(file, strippedFile, "New file should be created");
+  }
+
+  @Test
+  void shouldNotStrip_When_PngFile() throws IOException {
+    // Given
+    InMemoryFile file = InMemoryFile.create("test".getBytes(), "image/png");
+
+    // When
+    InMemoryFile strippedFile = imageProcessor.stripMetadata(file);
+
+    // Then
+    assertEquals(file, strippedFile, "Original file should be returned");
+  }
+
+  @Test
+  void shouldCalculateDimension_For_SmallerImages() {
+    // Given
+    int smallerWidth = 100;
+    int smallerHeight = 100;
+    int maxWidth = 1024;
+    int maxHeight = 1024;
+
+    // When
+    Dimension newDimension
+        = imageProcessor.calculateDimension(smallerWidth, smallerHeight, maxWidth, maxHeight);
+
+    // Then
+    assertAll(
+        () -> assertEquals(smallerWidth, newDimension.width, "Width should be equal"),
+        () -> assertEquals(smallerHeight, newDimension.height, "Height should be equal")
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("invalidImageDimensions")
+  void shouldCalculateDimension_For_BiggerImages(DimensionHelper dimensionHelper) {
+    // Given
+    double expectedRatio = Math.min(dimensionHelper.widthRatio, dimensionHelper.heightRatio);
+    int expectedWidth = (int) (dimensionHelper.inputDimension.width * expectedRatio);
+    int expectedHeight = (int) (dimensionHelper.inputDimension.height * expectedRatio);
+
+    int biggerWidth = dimensionHelper.inputDimension.width;
+    int biggerHeight = dimensionHelper.inputDimension.height;
+    int maxWidth = dimensionHelper.maxDimension.width;
+    int maxHeight = dimensionHelper.maxDimension.height;
+
+    // When
+    Dimension newDimension
+        = imageProcessor.calculateDimension(biggerWidth, biggerHeight, maxWidth, maxHeight);
+
+    // Then
+    assertAll(
+        () -> assertEquals(expectedWidth, newDimension.width, "Width should be equal"),
+        () -> assertEquals(expectedHeight, newDimension.height, "Height should be equal")
+    );
+  }
+
+  @Test
+  void shouldResizeImage() throws IOException {
+    // Given
+    BufferedImage mockImage = mock(BufferedImage.class);
+    InMemoryFile file = InMemoryFile.create("test".getBytes(), "image/png");
+    int imageDimension = 2 * MAX_RESIZE_DIMENSION;
+
+    doReturn(mockImage).when(imageService).getBufferedImage(file);
+    when(mockImage.getWidth()).thenReturn(imageDimension);
+    when(mockImage.getHeight()).thenReturn(imageDimension);
+    when(mockImage.getType()).thenReturn(BufferedImage.TYPE_INT_RGB);
+
+    // When
+    BufferedImage newImage = imageProcessor.resizeImage(file);
+
+    // Then
+    assertAll(
+        () -> assertEquals(MAX_RESIZE_DIMENSION, newImage.getWidth(),
+            "Image should be correctly resized"),
+        () -> assertEquals(MAX_RESIZE_DIMENSION, newImage.getHeight(),
+            "Image should be correctly resized")
+    );
+  }
+
+  @Test
+  void shouldCleanImage() {
+    // Given
+    int imageDimension = 2 * MAX_RESIZE_DIMENSION;
+    BufferedImage mockImage = new SimpleBufferedImageFactory()
+        .getColorBufferedImage(imageDimension, imageDimension, true);
+
+    // When
+    BufferedImage cleanImage = imageProcessor.cleanImage(mockImage);
+
+    // Then
+    assertAll(
+        () -> assertEquals(BufferedImage.TYPE_INT_RGB, cleanImage.getType(),
+            "Image type should be RGB"),
+        () -> assertEquals(imageDimension, cleanImage.getWidth(), "Image width should be equal"),
+        () -> assertEquals(imageDimension, cleanImage.getHeight(), "Image height should be equal")
+    );
+  }
+
+  private static final class DimensionHelper {
+    private final Dimension inputDimension;
+    private final Dimension maxDimension;
+    private final double widthRatio;
+    private final double heightRatio;
+
+    private DimensionHelper(Dimension inputDimension, Dimension maxDimension) {
+      this.inputDimension = inputDimension;
+      this.maxDimension = maxDimension;
+      this.widthRatio = (double) maxDimension.width / inputDimension.width;
+      this.heightRatio = (double) maxDimension.height / inputDimension.height;
+    }
+  }
+}

--- a/backend/profile-service/src/test/java/org/maxq/profileservice/service/message/handler/ProfileImageUploadHandlerTest.java
+++ b/backend/profile-service/src/test/java/org/maxq/profileservice/service/message/handler/ProfileImageUploadHandlerTest.java
@@ -1,15 +1,18 @@
 package org.maxq.profileservice.service.message.handler;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 import org.maxq.profileservice.domain.InMemoryFile;
 import org.maxq.profileservice.domain.dto.ImageDto;
 import org.maxq.profileservice.mapper.InMemoryFileMapper;
-import org.maxq.profileservice.service.image.ImageService;
+import org.maxq.profileservice.service.image.ApacheImageService;
+import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
+import java.awt.image.BufferedImage;
 import java.io.IOException;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -24,7 +27,16 @@ class ProfileImageUploadHandlerTest {
   @MockitoBean
   private InMemoryFileMapper inMemoryFileMapper;
   @MockitoBean
-  private ImageService imageService;
+  private ApacheImageService imageService;
+
+  @Mock
+  private BufferedImage mockImage;
+
+  @BeforeEach
+  void setUp() {
+    when(mockImage.getWidth()).thenReturn(1024);
+    when(mockImage.getHeight()).thenReturn(1024);
+  }
 
   @Test
   void shouldHandleMessage_When_ProcessingSuccess() throws IOException {
@@ -37,12 +49,14 @@ class ProfileImageUploadHandlerTest {
     );
     when(inMemoryFileMapper.mapToInMemoryFile(imageDto)).thenReturn(file);
     when(imageService.stripMetadata(file)).thenReturn(file);
+    when(imageService.resizeImage(file)).thenReturn(mockImage);
 
     // When
     handler.handleMessage(imageDto);
 
     // Then
     verify(imageService, times(1)).stripMetadata(file);
+    verify(imageService, times(1)).resizeImage(file);
   }
 
   @Test
@@ -56,6 +70,27 @@ class ProfileImageUploadHandlerTest {
     );
     when(inMemoryFileMapper.mapToInMemoryFile(imageDto)).thenReturn(file);
     doThrow(IOException.class).when(imageService).stripMetadata(file);
+
+    // When + Then
+    Executable executable = () -> handler.handleMessage(imageDto);
+
+    // Then
+    assertDoesNotThrow(executable);
+    verify(imageService, times(1)).stripMetadata(file);
+  }
+
+  @Test
+  void shouldHandleMessage_When_ResizingFailed() throws IOException {
+    // Given
+    ImageDto imageDto = new ImageDto("test@test.com", "test.jpeg", "image/jpeg", "test-data".getBytes());
+    InMemoryFile file = new InMemoryFile(
+        imageDto.getContentType(),
+        imageDto.getName(),
+        imageDto.getData()
+    );
+    when(inMemoryFileMapper.mapToInMemoryFile(imageDto)).thenReturn(file);
+    when(imageService.stripMetadata(file)).thenReturn(file);
+    doThrow(IOException.class).when(imageService).resizeImage(file);
 
     // When + Then
     Executable executable = () -> handler.handleMessage(imageDto);

--- a/backend/profile-service/src/test/java/org/maxq/profileservice/service/message/handler/ProfileImageUploadHandlerTest.java
+++ b/backend/profile-service/src/test/java/org/maxq/profileservice/service/message/handler/ProfileImageUploadHandlerTest.java
@@ -1,0 +1,67 @@
+package org.maxq.profileservice.service.message.handler;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+import org.maxq.profileservice.domain.InMemoryFile;
+import org.maxq.profileservice.domain.dto.ImageDto;
+import org.maxq.profileservice.mapper.InMemoryFileMapper;
+import org.maxq.profileservice.service.image.ImageService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+class ProfileImageUploadHandlerTest {
+
+  @Autowired
+  private ProfileImageUploadHandler handler;
+
+  @MockitoBean
+  private InMemoryFileMapper inMemoryFileMapper;
+  @MockitoBean
+  private ImageService imageService;
+
+  @Test
+  void shouldHandleMessage_When_ProcessingSuccess() throws IOException {
+    // Given
+    ImageDto imageDto = new ImageDto("test@test.com", "test.jpeg", "image/jpeg", "test-data".getBytes());
+    InMemoryFile file = new InMemoryFile(
+        imageDto.getContentType(),
+        imageDto.getName(),
+        imageDto.getData()
+    );
+    when(inMemoryFileMapper.mapToInMemoryFile(imageDto)).thenReturn(file);
+    when(imageService.stripMetadata(file)).thenReturn(file);
+
+    // When
+    handler.handleMessage(imageDto);
+
+    // Then
+    verify(imageService, times(1)).stripMetadata(file);
+  }
+
+  @Test
+  void shouldHandleMessage_When_MetadataStrippingFailed() throws IOException {
+    // Given
+    ImageDto imageDto = new ImageDto("test@test.com", "test.jpeg", "image/jpeg", "test-data".getBytes());
+    InMemoryFile file = new InMemoryFile(
+        imageDto.getContentType(),
+        imageDto.getName(),
+        imageDto.getData()
+    );
+    when(inMemoryFileMapper.mapToInMemoryFile(imageDto)).thenReturn(file);
+    doThrow(IOException.class).when(imageService).stripMetadata(file);
+
+    // When + Then
+    Executable executable = () -> handler.handleMessage(imageDto);
+
+    // Then
+    assertDoesNotThrow(executable);
+    verify(imageService, times(1)).stripMetadata(file);
+  }
+}

--- a/backend/profile-service/src/test/java/org/maxq/profileservice/service/validation/ValidationServiceFactoryTest.java
+++ b/backend/profile-service/src/test/java/org/maxq/profileservice/service/validation/ValidationServiceFactoryTest.java
@@ -2,7 +2,7 @@ package org.maxq.profileservice.service.validation;
 
 import org.junit.jupiter.api.Test;
 import org.maxq.profileservice.domain.InMemoryFile;
-import org.maxq.profileservice.service.image.ImageService;
+import org.maxq.profileservice.service.image.ApacheImageService;
 import org.maxq.profileservice.service.validation.file.ContentValidationService;
 import org.maxq.profileservice.service.validation.file.ImageContentValidationService;
 import org.maxq.profileservice.service.validation.file.ImageValidationService;
@@ -21,7 +21,7 @@ class ValidationServiceFactoryTest {
   private ValidationServiceFactory factory;
 
   @MockitoBean
-  private ImageService imageService;
+  private ApacheImageService imageService;
 
   @Test
   void shouldCreateImageValidationService() {

--- a/backend/profile-service/src/test/java/org/maxq/profileservice/service/validation/file/ImageContentValidationServiceTest.java
+++ b/backend/profile-service/src/test/java/org/maxq/profileservice/service/validation/file/ImageContentValidationServiceTest.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.maxq.profileservice.domain.*;
 import org.maxq.profileservice.domain.exception.FileValidationException;
-import org.maxq.profileservice.service.image.ImageService;
+import org.maxq.profileservice.service.image.ApacheImageService;
 import org.mockito.Mock;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -58,7 +58,7 @@ class ImageContentValidationServiceTest {
   );
 
   @MockitoBean
-  private ImageService imageService;
+  private ApacheImageService imageService;
 
   @Mock
   private JpegImageParser imageParser;

--- a/frontend/src/components/profile/Profile.tsx
+++ b/frontend/src/components/profile/Profile.tsx
@@ -1,13 +1,4 @@
-import {
-  Badge,
-  Box,
-  Flex,
-  Grid,
-  Heading,
-  Link,
-  Separator,
-  Skeleton,
-} from '@radix-ui/themes';
+import { Badge, Box, Flex, Grid, Heading, Link, Separator, Skeleton, } from '@radix-ui/themes';
 import {
   useMyProfileQuery,
   useUpdateMyProfileImageMutation,
@@ -15,7 +6,7 @@ import {
 } from '../../store/api/profile.ts';
 import ProfileSection from './ProfileSection.tsx';
 import ProfileItem from './ProfileItem.tsx';
-import { FormEvent, useState } from 'react';
+import { FormEvent, useMemo, useState } from 'react';
 import Form from '../shared/form/Form.tsx';
 import ProfileControls from './ProfileControls.tsx';
 import { UpdateProfileType } from '../../types/api/ProfileTypes.ts';
@@ -44,14 +35,17 @@ const Profile = () => {
     },
   ] = useUpdateMyProfileImageMutation();
 
-  const imageUploadErrorMessage =
-    imageUploadErrorData &&
-    ('cause' in imageUploadErrorData && imageUploadErrorData.cause
+  const imageUploadErrorMessage = useMemo(() => {
+    if (!imageUploadErrorData) {
+      return undefined;
+    }
+    return 'cause' in imageUploadErrorData && imageUploadErrorData.cause
       ? ({
           message: imageUploadErrorData.message,
           cause: imageUploadErrorData.cause,
         } as MessageWithCause)
-      : imageUploadErrorData.message);
+      : imageUploadErrorData.message;
+  }, [imageUploadErrorData]);
 
   useFormNotifications({
     success: {

--- a/frontend/src/components/profile/Profile.tsx
+++ b/frontend/src/components/profile/Profile.tsx
@@ -46,7 +46,7 @@ const Profile = () => {
 
   const imageUploadErrorMessage =
     imageUploadErrorData &&
-    ('cause' in imageUploadErrorData
+    ('cause' in imageUploadErrorData && imageUploadErrorData.cause
       ? ({
           message: imageUploadErrorData.message,
           cause: imageUploadErrorData.cause,

--- a/frontend/src/components/profile/Profile.tsx
+++ b/frontend/src/components/profile/Profile.tsx
@@ -1,4 +1,13 @@
-import { Badge, Box, Flex, Grid, Heading, Link, Separator, Skeleton, } from '@radix-ui/themes';
+import {
+  Badge,
+  Box,
+  Flex,
+  Grid,
+  Heading,
+  Link,
+  Separator,
+  Skeleton,
+} from '@radix-ui/themes';
 import {
   useMyProfileQuery,
   useUpdateMyProfileImageMutation,

--- a/frontend/tests/components/PasswordRequestForm.test.tsx
+++ b/frontend/tests/components/PasswordRequestForm.test.tsx
@@ -209,6 +209,7 @@ describe('Password Request Form', () => {
 
     it('Should navigate to home when success', () => {
       // Given
+      vi.mocked(useRef).mockRestore();
       vi.spyOn(
         passwordApiSlice,
         'useRequestPasswordResetMutation'
@@ -240,6 +241,7 @@ describe('Password Request Form', () => {
 
     it('Should register successfull modal when success', () => {
       // Given
+      vi.mocked(useRef).mockRestore();
       vi.spyOn(
         passwordApiSlice,
         'useRequestPasswordResetMutation'

--- a/frontend/tests/components/PasswordUpdateForm.test.tsx
+++ b/frontend/tests/components/PasswordUpdateForm.test.tsx
@@ -260,6 +260,7 @@ describe('Password Update Form', () => {
 
     it('Should register successfull modal when success', () => {
       // Given
+      vi.mocked(useRef).mockRestore();
       vi.spyOn(passwordApiSlice, 'usePasswordUpdateMutation').mockReturnValue([
         mockMutate,
         {
@@ -295,6 +296,7 @@ describe('Password Update Form', () => {
 
     it('Should register error modal with error', () => {
       // Given
+      vi.mocked(useRef).mockRestore();
       const errorMessage = 'Test Error';
       vi.spyOn(passwordApiSlice, 'usePasswordUpdateMutation').mockReturnValue([
         mockMutate,
@@ -334,6 +336,7 @@ describe('Password Update Form', () => {
 
     it('Should register error modal with default error message', () => {
       // Given
+      vi.mocked(useRef).mockRestore();
       vi.spyOn(passwordApiSlice, 'usePasswordUpdateMutation').mockReturnValue([
         mockMutate,
         {

--- a/frontend/tests/components/RegisterForm.test.tsx
+++ b/frontend/tests/components/RegisterForm.test.tsx
@@ -332,6 +332,7 @@ describe('Register Form', () => {
 
     it('Should navigate to home when success', () => {
       // Given
+      vi.mocked(useRef).mockRestore();
       vi.spyOn(authApiSlice, 'useRegisterMutation').mockReturnValue([
         mockMutate,
         {

--- a/frontend/tests/components/profile/Profile.test.tsx
+++ b/frontend/tests/components/profile/Profile.test.tsx
@@ -490,6 +490,41 @@ describe('Profile', () => {
       });
     });
 
+    it('Should dispatch error modal when no cause undefined', () => {
+      // Given
+      const errorMessage = 'Error message';
+      vi.spyOn(
+        profileApiModule,
+        'useUpdateMyProfileImageMutation'
+      ).mockReturnValue([
+        mockImageUpload,
+        {
+          isSuccess: false,
+          isError: true,
+          isPending: false,
+          error: {
+            message: errorMessage,
+            cause: undefined,
+          },
+          reset: vi.fn(),
+        },
+      ]);
+
+      // When
+      const { store } = renderWithProviders(<Profile />);
+
+      // Then
+      const modalSlice = store.getState().modal;
+      expect(modalSlice.modals).toContainEqual({
+        content: {
+          type: 'error',
+          message: errorMessage,
+          hideTimeout: 30_000,
+        },
+        id: expect.any(String) as string,
+      });
+    });
+
     it('Should dispatch error modal with cause', () => {
       // Given
       const errorMessage = 'Error message';


### PR DESCRIPTION
Added basic image processing during image upload message handling.

1. Added metadata stripping from JPEG files - removing EXIF, XMP nad IPTC metadata.
2. Added image resizing to max size of 1024x1024 - resizing is always keeping the original ratio
3. Added image cleanup (writing to clean white background)
4. Added image writing to JPEG - no matter the original (PNG or JPEG) image type. Aplha channel is also removed from an image.

Additionally, solved issue on frontend with multiple modal messages being dispatched and registered.