### PR TITLE
[BE] Image serving endpoint GET /profiles/me/image

### DIFF
--- a/backend/profile-service/src/main/java/org/maxq/profileservice/config/controller/GlobalHttpErrorHandler.java
+++ b/backend/profile-service/src/main/java/org/maxq/profileservice/config/controller/GlobalHttpErrorHandler.java
@@ -3,6 +3,7 @@ package org.maxq.profileservice.config.controller;
 import lombok.extern.slf4j.Slf4j;
 import org.maxq.profileservice.domain.HttpErrorMessage;
 import org.maxq.profileservice.domain.HttpValidationStatus;
+import org.maxq.profileservice.domain.exception.BucketOperationException;
 import org.maxq.profileservice.domain.exception.ElementNotFoundException;
 import org.maxq.profileservice.domain.exception.FileValidationException;
 import org.springframework.http.HttpHeaders;
@@ -35,6 +36,12 @@ public class GlobalHttpErrorHandler extends ResponseEntityExceptionHandler {
         new HttpValidationStatus(e.getMessage(), e.getValidationResult().getMessages()),
         HttpStatus.BAD_REQUEST
     );
+  }
+
+  @ExceptionHandler(BucketOperationException.class)
+  public ResponseEntity<HttpErrorMessage> handleBucketOperationException(BucketOperationException e) {
+    log.error(e.getMessage(), e);
+    return new ResponseEntity<>(new HttpErrorMessage(e.getMessage()), HttpStatus.INTERNAL_SERVER_ERROR);
   }
 
   @Override

--- a/backend/profile-service/src/main/java/org/maxq/profileservice/controller/ProfileController.java
+++ b/backend/profile-service/src/main/java/org/maxq/profileservice/controller/ProfileController.java
@@ -6,18 +6,22 @@ import lombok.extern.slf4j.Slf4j;
 import org.maxq.profileservice.controller.api.ProfileApi;
 import org.maxq.profileservice.domain.InMemoryFile;
 import org.maxq.profileservice.domain.Profile;
+import org.maxq.profileservice.domain.ProfileImage;
 import org.maxq.profileservice.domain.dto.ImageDto;
 import org.maxq.profileservice.domain.dto.ProfileDto;
 import org.maxq.profileservice.domain.dto.UpdateProfileDto;
+import org.maxq.profileservice.domain.exception.BucketOperationException;
 import org.maxq.profileservice.domain.exception.ElementNotFoundException;
 import org.maxq.profileservice.domain.exception.FileValidationException;
 import org.maxq.profileservice.event.message.RabbitmqMessage;
 import org.maxq.profileservice.mapper.InMemoryFileMapper;
 import org.maxq.profileservice.mapper.ProfileMapper;
+import org.maxq.profileservice.service.ProfileImageService;
 import org.maxq.profileservice.service.ProfileService;
 import org.maxq.profileservice.service.message.publisher.MessageService;
-import org.maxq.profileservice.service.validation.ValidationServiceFactory;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
@@ -33,10 +37,10 @@ import java.io.IOException;
 public class ProfileController implements ProfileApi {
 
   private final ProfileService profileService;
+  private final ProfileImageService profileImageService;
   private final ProfileMapper profileMapper;
   private final InMemoryFileMapper inMemoryFileMapper;
   private final MessageService<RabbitmqMessage<?>> messageService;
-  private final ValidationServiceFactory validationFactory;
 
   @Value("${profile.topic.update}")
   private String updateProfileTopic;
@@ -63,7 +67,6 @@ public class ProfileController implements ProfileApi {
     ProfileDto profileDtoToSave = new ProfileDto((String) authentication.getPrincipal(),
         profileDto.getFirstName(), profileDto.getMiddleName(), profileDto.getLastName());
     RabbitmqMessage<ProfileDto> message = new RabbitmqMessage<>(profileDtoToSave, updateProfileTopic);
-
     messageService.sendMessage(message);
     return ResponseEntity.ok().build();
   }
@@ -74,26 +77,25 @@ public class ProfileController implements ProfileApi {
   public ResponseEntity<Void> updateProfileImage(Authentication authentication,
                                                  @RequestParam("file") MultipartFile file) throws FileValidationException, IOException {
     log.info("Updating profile image for user: {}", authentication.getPrincipal());
-
-    validationFactory.createImageValidationService(file)
-        .validateName()
-        .validateExtension()
-        .validateContentType()
-        .validateSize()
-        .validate();
-
-    InMemoryFile newFile = InMemoryFile.create(file.getBytes(), file.getContentType());
-    log.info("New file: {}", newFile.getName());
-
-    validationFactory.createImageContentValidationService(newFile)
-        .validateSignature()
-        .validateRealContent()
-        .validateMetadata()
-        .validate();
-
+    InMemoryFile newFile = profileImageService.validateAndReturnImage(file);
     ImageDto image = inMemoryFileMapper.mapToImageDto(newFile, authentication.getPrincipal().toString());
+
     RabbitmqMessage<ImageDto> message = new RabbitmqMessage<>(image, imageUploadTopic);
     messageService.sendMessage(message);
     return ResponseEntity.ok().build();
+  }
+
+  @Override
+  @GetMapping("/me/image")
+  @PreAuthorize("authentication.principal != null")
+  public ResponseEntity<Resource> getMyProfileImage(Authentication authentication) throws ElementNotFoundException, BucketOperationException, IOException {
+    String email = (String) authentication.getPrincipal();
+    ProfileImage profileImage = profileService.getProfileImage(email);
+
+    Resource imageResource = profileImageService.getProfileImageFromStorage(profileImage);
+    return ResponseEntity.ok()
+        .contentType(MediaType.IMAGE_JPEG)
+        .contentLength(imageResource.contentLength())
+        .body(imageResource);
   }
 }

--- a/backend/profile-service/src/main/java/org/maxq/profileservice/controller/api/ProfileApi.java
+++ b/backend/profile-service/src/main/java/org/maxq/profileservice/controller/api/ProfileApi.java
@@ -8,8 +8,10 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.maxq.profileservice.domain.HttpErrorMessage;
 import org.maxq.profileservice.domain.dto.ProfileDto;
 import org.maxq.profileservice.domain.dto.UpdateProfileDto;
+import org.maxq.profileservice.domain.exception.BucketOperationException;
 import org.maxq.profileservice.domain.exception.ElementNotFoundException;
 import org.maxq.profileservice.domain.exception.FileValidationException;
+import org.springframework.core.io.Resource;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.multipart.MultipartFile;
@@ -92,4 +94,33 @@ public interface ProfileApi {
           @Content(mediaType = "application/json", schema = @Schema(implementation = HttpErrorMessage.class))
       })
   ResponseEntity<Void> updateProfileImage(Authentication authentication, MultipartFile file) throws FileValidationException, IOException;
+
+  @Operation(
+      summary = "Return my profile image",
+      description = "Returns user's profile image of currently logged in user"
+  )
+  @ApiResponse(responseCode = "200", description = "User profile image properly returned",
+      content = {
+          @Content(
+              mediaType = "application/json",
+              schema = @Schema(implementation = ProfileDto.class)
+          )
+      })
+  @ApiResponse(responseCode = "401",
+      description = "Unauthenticated - only request with Robot Token are passed",
+      content = {
+          @Content(mediaType = "application/json", schema = @Schema(implementation = HttpErrorMessage.class))
+      })
+  @ApiResponse(responseCode = "403",
+      description = "Unauthorized - only logged in users can access this resource",
+      content = {
+          @Content(mediaType = "application/json", schema = @Schema(implementation = HttpErrorMessage.class))
+      })
+  @ApiResponse(responseCode = "404",
+      description = "Not found - profile or profile image for this user does not exists",
+      content = {
+          @Content(mediaType = "application/json", schema = @Schema(implementation = HttpErrorMessage.class))
+      })
+  ResponseEntity<Resource> getMyProfileImage(Authentication authentication)
+      throws ElementNotFoundException, BucketOperationException, IOException;
 }

--- a/backend/profile-service/src/main/java/org/maxq/profileservice/domain/dto/BucketOperationResponse.java
+++ b/backend/profile-service/src/main/java/org/maxq/profileservice/domain/dto/BucketOperationResponse.java
@@ -8,4 +8,5 @@ import lombok.Getter;
 public class BucketOperationResponse {
   private boolean successful;
   private int statusCode;
+  private byte[] data;
 }

--- a/backend/profile-service/src/main/java/org/maxq/profileservice/mapper/BucketOperationResponseMapper.java
+++ b/backend/profile-service/src/main/java/org/maxq/profileservice/mapper/BucketOperationResponseMapper.java
@@ -2,7 +2,10 @@ package org.maxq.profileservice.mapper;
 
 import org.maxq.profileservice.domain.dto.BucketOperationResponse;
 import org.springframework.stereotype.Service;
+import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.core.SdkResponse;
+import software.amazon.awssdk.http.SdkHttpResponse;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 
 @Service
 public class BucketOperationResponseMapper {
@@ -10,7 +13,17 @@ public class BucketOperationResponseMapper {
   public BucketOperationResponse mapToBucketOperationResponse(SdkResponse sdkResponse) {
     return new BucketOperationResponse(
         sdkResponse.sdkHttpResponse().isSuccessful(),
-        sdkResponse.sdkHttpResponse().statusCode()
+        sdkResponse.sdkHttpResponse().statusCode(),
+        null
+    );
+  }
+
+  public BucketOperationResponse mapToBucketOperationResponse(ResponseBytes<GetObjectResponse> response) {
+    SdkHttpResponse httpResponse = response.response().sdkHttpResponse();
+    return new BucketOperationResponse(
+        httpResponse.isSuccessful(),
+        httpResponse.statusCode(),
+        response.asByteArray()
     );
   }
 }

--- a/backend/profile-service/src/main/java/org/maxq/profileservice/service/ProfileImageService.java
+++ b/backend/profile-service/src/main/java/org/maxq/profileservice/service/ProfileImageService.java
@@ -1,0 +1,51 @@
+package org.maxq.profileservice.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.maxq.profileservice.domain.InMemoryFile;
+import org.maxq.profileservice.domain.ProfileImage;
+import org.maxq.profileservice.domain.dto.BucketOperationResponse;
+import org.maxq.profileservice.domain.exception.BucketOperationException;
+import org.maxq.profileservice.domain.exception.FileValidationException;
+import org.maxq.profileservice.service.image.upload.ImageUploadService;
+import org.maxq.profileservice.service.validation.ValidationServiceFactory;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.Resource;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ProfileImageService {
+
+  private final ValidationServiceFactory validationFactory;
+  private final ImageUploadService uploadService;
+
+  public InMemoryFile validateAndReturnImage(MultipartFile file) throws FileValidationException, IOException {
+    validationFactory.createImageValidationService(file)
+        .validateName()
+        .validateExtension()
+        .validateContentType()
+        .validateSize()
+        .validate();
+
+    InMemoryFile newFile = InMemoryFile.create(file.getBytes(), file.getContentType());
+    log.info("New file: {}", newFile.getName());
+
+    validationFactory.createImageContentValidationService(newFile)
+        .validateSignature()
+        .validateRealContent()
+        .validateMetadata()
+        .validate();
+
+    return newFile;
+  }
+
+  public Resource getProfileImageFromStorage(ProfileImage image) throws BucketOperationException {
+    BucketOperationResponse response = uploadService.getImage(image.getName());
+    return new ByteArrayResource(response.getData());
+  }
+}

--- a/backend/profile-service/src/main/java/org/maxq/profileservice/service/ProfileService.java
+++ b/backend/profile-service/src/main/java/org/maxq/profileservice/service/ProfileService.java
@@ -12,6 +12,8 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.TransactionSystemException;
 
+import java.util.Optional;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -63,5 +65,15 @@ public class ProfileService {
     profileRepository.save(profile);
   }
 
+  public ProfileImage getProfileImage(String email) throws ElementNotFoundException {
+    Profile profile = this.getProfileByEmail(email);
+    Optional<ProfileImage> optionalProfileImage = Optional.ofNullable(profile.getProfileImage());
+
+    if (optionalProfileImage.isEmpty()) {
+      throw new ElementNotFoundException("Image does not exist for a given user: " + email);
+    }
+
+    return optionalProfileImage.get();
+  }
 }
 

--- a/backend/profile-service/src/main/java/org/maxq/profileservice/service/image/upload/ImageUploadService.java
+++ b/backend/profile-service/src/main/java/org/maxq/profileservice/service/image/upload/ImageUploadService.java
@@ -2,8 +2,11 @@ package org.maxq.profileservice.service.image.upload;
 
 import org.maxq.profileservice.domain.InMemoryFile;
 import org.maxq.profileservice.domain.dto.BucketOperationResponse;
+import org.maxq.profileservice.domain.exception.BucketOperationException;
 
 public interface ImageUploadService {
+
+  BucketOperationResponse getImage(String imageName) throws BucketOperationException;
 
   BucketOperationResponse uploadImage(InMemoryFile file);
 

--- a/backend/profile-service/src/main/java/org/maxq/profileservice/service/image/upload/QaImageUploadService.java
+++ b/backend/profile-service/src/main/java/org/maxq/profileservice/service/image/upload/QaImageUploadService.java
@@ -16,10 +16,17 @@ public class QaImageUploadService implements ImageUploadService {
   private String profileImageUploadBucket;
 
   @Override
+  public BucketOperationResponse getImage(String imageName) {
+    return new BucketOperationResponse(
+        true, 200, null
+    );
+  }
+
+  @Override
   public BucketOperationResponse deleteImage(String imageName) {
     log.info("Deleting image {} from bucket {}", imageName, profileImageUploadBucket);
     return new BucketOperationResponse(
-        true, 200
+        true, 200, null
     );
   }
 
@@ -27,7 +34,7 @@ public class QaImageUploadService implements ImageUploadService {
   public BucketOperationResponse uploadImage(InMemoryFile file) {
     log.info("Uploading image {} to bucket {}", file.getName(), profileImageUploadBucket);
     return new BucketOperationResponse(
-        true, 200
+        true, 200, null
     );
   }
 }

--- a/backend/profile-service/src/main/java/org/maxq/profileservice/service/image/upload/S3ImageUploadService.java
+++ b/backend/profile-service/src/main/java/org/maxq/profileservice/service/image/upload/S3ImageUploadService.java
@@ -3,16 +3,15 @@ package org.maxq.profileservice.service.image.upload;
 import lombok.RequiredArgsConstructor;
 import org.maxq.profileservice.domain.InMemoryFile;
 import org.maxq.profileservice.domain.dto.BucketOperationResponse;
+import org.maxq.profileservice.domain.exception.BucketOperationException;
 import org.maxq.profileservice.mapper.BucketOperationResponseMapper;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
+import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
-import software.amazon.awssdk.services.s3.model.DeleteObjectResponse;
-import software.amazon.awssdk.services.s3.model.PutObjectRequest;
-import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+import software.amazon.awssdk.services.s3.model.*;
 
 @Service
 @Profile("!QA & !SIT")
@@ -24,6 +23,27 @@ public class S3ImageUploadService implements ImageUploadService {
 
   @Value("${aws.s3.profile-images.bucket}")
   private String profileImageUploadBucket;
+
+  @Override
+  public BucketOperationResponse getImage(String imageName) throws BucketOperationException {
+    GetObjectRequest request = GetObjectRequest.builder()
+        .bucket(profileImageUploadBucket)
+        .key(imageName)
+        .build();
+    ResponseBytes<GetObjectResponse> response = profileImageUploadClient.getObjectAsBytes(request);
+    BucketOperationResponse operationResponse = responseMapper.mapToBucketOperationResponse(response);
+
+    if (!operationResponse.isSuccessful()) {
+      throw new BucketOperationException("Fetching image " + imageName
+          + " failed with status code: " + operationResponse.getStatusCode());
+    }
+
+    if (operationResponse.getData() == null) {
+      throw new BucketOperationException("No image data for: " + imageName);
+    }
+
+    return operationResponse;
+  }
 
   @Override
   public BucketOperationResponse uploadImage(InMemoryFile file) {

--- a/backend/profile-service/src/test/java/org/maxq/profileservice/mapper/BucketOperationResponseMapperTest.java
+++ b/backend/profile-service/src/test/java/org/maxq/profileservice/mapper/BucketOperationResponseMapperTest.java
@@ -4,8 +4,10 @@ import org.junit.jupiter.api.Test;
 import org.maxq.profileservice.domain.dto.BucketOperationResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.http.SdkHttpResponse;
 import software.amazon.awssdk.services.s3.model.DeleteObjectResponse;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -51,5 +53,26 @@ class BucketOperationResponseMapperTest {
     assertFalse(mappedResponse.isSuccessful(), "Mapped response should be failed");
     assertEquals(404, mappedResponse.getStatusCode(),
         "Mapped response should have correct status code");
+  }
+
+  @Test
+  void shouldMapToBucketOperationResponse_When_responseWithData() {
+    // Given
+    SdkHttpResponse httpResponse = SdkHttpResponse.builder()
+        .statusCode(200)
+        .build();
+    GetObjectResponse getObjectResponse = (GetObjectResponse) GetObjectResponse.builder()
+        .sdkHttpResponse(httpResponse)
+        .build();
+    byte[] data = "test-data".getBytes();
+    ResponseBytes<GetObjectResponse> response = ResponseBytes.fromByteArray(getObjectResponse, data);
+
+    // When
+    BucketOperationResponse mappedResponse = mapper.mapToBucketOperationResponse(response);
+   
+    // Then
+    assertTrue(mappedResponse.isSuccessful(), "Mapped response should be successful");
+    assertEquals(200, mappedResponse.getStatusCode(), "Mapped response should have correct status code");
+    assertArrayEquals(data, mappedResponse.getData(), "Mapped response should have correct data");
   }
 }

--- a/backend/profile-service/src/test/java/org/maxq/profileservice/service/ProfileImageServiceTest.java
+++ b/backend/profile-service/src/test/java/org/maxq/profileservice/service/ProfileImageServiceTest.java
@@ -1,0 +1,242 @@
+package org.maxq.profileservice.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+import org.maxq.profileservice.domain.InMemoryFile;
+import org.maxq.profileservice.domain.ProfileImage;
+import org.maxq.profileservice.domain.ValidationError;
+import org.maxq.profileservice.domain.ValidationResult;
+import org.maxq.profileservice.domain.dto.BucketOperationResponse;
+import org.maxq.profileservice.domain.exception.BucketOperationException;
+import org.maxq.profileservice.domain.exception.FileValidationException;
+import org.maxq.profileservice.service.image.upload.ImageUploadService;
+import org.maxq.profileservice.service.validation.ValidationServiceFactory;
+import org.maxq.profileservice.service.validation.file.ImageContentValidationService;
+import org.maxq.profileservice.service.validation.file.ImageValidationService;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.io.Resource;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+class ProfileImageServiceTest {
+
+  private final MockMultipartFile mockMultipartFile
+      = new MockMultipartFile("file", "image.jpeg", "image/jpeg", "test-content".getBytes());
+
+  @Autowired
+  private ProfileImageService service;
+
+  @MockitoBean
+  private ValidationServiceFactory validationFactory;
+  @MockitoBean
+  private ImageUploadService uploadService;
+
+  @Mock
+  private ImageValidationService validationService;
+  @Mock
+  private ImageContentValidationService contentValidationService;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    when(validationFactory.createImageValidationService(any(MultipartFile.class)))
+        .thenReturn(validationService);
+    when(validationFactory.createImageContentValidationService(any(InMemoryFile.class)))
+        .thenReturn(contentValidationService);
+
+    when(validationService.validateName()).thenReturn(validationService);
+    when(validationService.validateExtension()).thenReturn(validationService);
+    when(validationService.validateContentType()).thenReturn(validationService);
+    when(validationService.validateSize()).thenReturn(validationService);
+
+    when(contentValidationService.validateSignature()).thenReturn(contentValidationService);
+    when(contentValidationService.validateRealContent()).thenReturn(contentValidationService);
+    when(contentValidationService.validateMetadata()).thenReturn(contentValidationService);
+  }
+
+  @Test
+  void shouldNotThrow_When_ValidationSuccessful() throws Exception {
+    // Given
+    doNothing().when(validationService).validate();
+    doNothing().when(contentValidationService).validate();
+
+    // When
+    Executable executable = () -> service.validateAndReturnImage(mockMultipartFile);
+
+    // Then
+    assertDoesNotThrow(executable, "Should throw exception when failed validation");
+    assertAll(
+        () -> verify(validationService, times(1)).validateName(),
+        () -> verify(validationService, times(1)).validateExtension(),
+        () -> verify(validationService, times(1)).validateContentType(),
+        () -> verify(validationService, times(1)).validateSize(),
+        () -> verify(validationService, times(1)).validate()
+    );
+    assertAll(
+        () -> verify(contentValidationService, times(1)).validateSignature(),
+        () -> verify(contentValidationService, times(1)).validateRealContent(),
+        () -> verify(contentValidationService, times(1)).validateMetadata(),
+        () -> verify(contentValidationService, times(1)).validate()
+    );
+  }
+
+  @Test
+  void shouldThrow_When_ValidationFailed() throws Exception {
+    // Given
+    String testError = "Test error";
+    ValidationError error = ValidationError.FILE_NAME;
+    ValidationResult validationResult = new ValidationResult();
+    validationResult.addError(error);
+
+    doThrow(new FileValidationException(testError, validationResult)).when(validationService).validate();
+
+    // When
+    Executable executable = () -> service.validateAndReturnImage(mockMultipartFile);
+
+    // Then
+    FileValidationException exception = assertThrows(FileValidationException.class, executable,
+        "Should throw exception when failed validation");
+    assertFalse(exception.getValidationResult().isValid(), "Validation result should be invalid");
+    assertEquals(validationResult.getMessages(), exception.getValidationResult().getMessages(),
+        "Wrong validation result");
+    assertAll(
+        () -> verify(validationService, times(1)).validateName(),
+        () -> verify(validationService, times(1)).validateExtension(),
+        () -> verify(validationService, times(1)).validateContentType(),
+        () -> verify(validationService, times(1)).validateSize(),
+        () -> verify(validationService, times(1)).validate()
+    );
+  }
+
+  @Test
+  void shouldThrow_When_MultipleValidationsFailed() throws Exception {
+    // Given
+    String testError = "Test error";
+    ValidationError fileNameError = ValidationError.FILE_NAME;
+    ValidationError fileExtensionError = ValidationError.FILE_EXTENSION;
+    ValidationResult validationResult = new ValidationResult();
+    validationResult.addError(fileNameError);
+    validationResult.addError(fileExtensionError);
+
+    doThrow(new FileValidationException(testError, validationResult)).when(validationService).validate();
+
+    // When
+    Executable executable = () -> service.validateAndReturnImage(mockMultipartFile);
+
+    // Then
+    FileValidationException exception = assertThrows(FileValidationException.class, executable,
+        "Should throw exception when failed validation");
+    assertFalse(exception.getValidationResult().isValid(), "Validation result should be invalid");
+    assertEquals(validationResult.getMessages(), exception.getValidationResult().getMessages(),
+        "Wrong validation result");
+    assertAll(
+        () -> verify(validationService, times(1)).validateName(),
+        () -> verify(validationService, times(1)).validateExtension(),
+        () -> verify(validationService, times(1)).validateContentType(),
+        () -> verify(validationService, times(1)).validateSize(),
+        () -> verify(validationService, times(1)).validate()
+    );
+  }
+
+  @Test
+  void shouldThrow_When_ContentValidationFailed() throws Exception {
+    // Given
+    String testError = "Test error";
+    ValidationError error = ValidationError.FILE_REAL_FORMAT;
+    ValidationResult validationResult = new ValidationResult();
+    validationResult.addError(error);
+
+    doThrow(new FileValidationException(testError, validationResult))
+        .when(contentValidationService).validate();
+
+    // When
+    Executable executable = () -> service.validateAndReturnImage(mockMultipartFile);
+
+    // Then
+    FileValidationException exception = assertThrows(FileValidationException.class, executable,
+        "Should throw exception when failed validation");
+    assertFalse(exception.getValidationResult().isValid(), "Validation result should be invalid");
+    assertEquals(validationResult.getMessages(), exception.getValidationResult().getMessages(),
+        "Wrong validation result");
+    assertAll(
+
+        () -> verify(contentValidationService, times(1)).validateSignature(),
+        () -> verify(contentValidationService, times(1)).validateRealContent(),
+        () -> verify(contentValidationService, times(1)).validateMetadata(),
+        () -> verify(contentValidationService, times(1)).validate()
+    );
+  }
+
+  @Test
+  void shouldThrow_When_MultipleContentValidationsFailed() throws Exception {
+    // Given
+    String testError = "Test error";
+    ValidationError fileRealFormat = ValidationError.FILE_REAL_FORMAT;
+    ValidationError fileContentType = ValidationError.FILE_CONTENT_TYPE;
+    ValidationResult validationResult = new ValidationResult();
+    validationResult.addError(fileRealFormat);
+    validationResult.addError(fileContentType);
+
+    doThrow(new FileValidationException(testError, validationResult)).when(contentValidationService).validate();
+
+    // When
+    Executable executable = () -> service.validateAndReturnImage(mockMultipartFile);
+
+    // Then
+    FileValidationException exception = assertThrows(FileValidationException.class, executable,
+        "Should throw exception when failed validation");
+    assertFalse(exception.getValidationResult().isValid(), "Validation result should be invalid");
+    assertEquals(validationResult.getMessages(), exception.getValidationResult().getMessages(),
+        "Wrong validation result");
+    assertAll(
+        () -> verify(contentValidationService, times(1)).validateSignature(),
+        () -> verify(contentValidationService, times(1)).validateRealContent(),
+        () -> verify(contentValidationService, times(1)).validateMetadata(),
+        () -> verify(contentValidationService, times(1)).validate()
+    );
+  }
+
+  @Test
+  void shouldReturnProfileImageFromStorage() throws BucketOperationException, IOException {
+    // Given
+    String imageName = "test.jpeg";
+    byte[] data = "test-data".getBytes();
+    ProfileImage profileImage = new ProfileImage(imageName, "image/jpeg", data.length);
+    BucketOperationResponse response = new BucketOperationResponse(
+        true, 200, data
+    );
+    when(uploadService.getImage(imageName)).thenReturn(response);
+
+    // When
+    Resource returnedResource = service.getProfileImageFromStorage(profileImage);
+
+    // Then
+    assertArrayEquals(data, returnedResource.getContentAsByteArray(),
+        "Correct content should be returned");
+  }
+
+  @Test
+  void shouldThrow_When_GetImage_When_BucketOperationFailed() throws BucketOperationException {
+    // Given
+    String imageName = "test.jpeg";
+    byte[] data = "test-data".getBytes();
+    ProfileImage profileImage = new ProfileImage(imageName, "image/jpeg", data.length);
+    doThrow(BucketOperationException.class).when(uploadService).getImage(imageName);
+
+    // When
+    Executable executable = () -> service.getProfileImageFromStorage(profileImage);
+
+    // Then
+    assertThrows(BucketOperationException.class, executable, "Exception should be thrown");
+  }
+}

--- a/backend/profile-service/src/test/java/org/maxq/profileservice/service/ProfileServiceTest.java
+++ b/backend/profile-service/src/test/java/org/maxq/profileservice/service/ProfileServiceTest.java
@@ -1,6 +1,7 @@
 package org.maxq.profileservice.service;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 import org.maxq.profileservice.domain.Profile;
 import org.maxq.profileservice.domain.ProfileImage;
 import org.maxq.profileservice.domain.exception.DataValidationException;
@@ -166,5 +167,61 @@ class ProfileServiceTest {
                 && profileImage.getContentType().equals(argument.getProfileImage().getContentType())
                 && profileImage.getSize() == argument.getProfileImage().getSize())
         );
+  }
+
+  @Test
+  void shouldReturnProfileImage() throws ElementNotFoundException {
+    // Given
+    String email = "test@test.com";
+    ProfileImage profileImage = new ProfileImage("test.jpeg", "image/jpeg", 10);
+    Profile profileWithImage = new Profile(1L, email, "Test", null, "User", profileImage);
+
+    ProfileService spyService = spy(profileService);
+    doReturn(profileWithImage).when(spyService).getProfileByEmail(anyString());
+
+    // When
+    ProfileImage returnedProfileImage = spyService.getProfileImage(email);
+
+    // Then
+    assertAll(
+        () -> assertEquals(profileImage.getName(), returnedProfileImage.getName(),
+            "Should return image with correct name"),
+        () -> assertEquals(profileImage.getContentType(), returnedProfileImage.getContentType(),
+            "Should return correct image content type"),
+        () -> assertEquals(profileImage.getSize(), returnedProfileImage.getSize(),
+            "Should return correct image size")
+    );
+  }
+
+  @Test
+  void shouldThrow_When_ReturnProfileImage_When_ProfileNotFound() throws ElementNotFoundException {
+    // Given
+    String email = "test@test.com";
+
+    ProfileService spyService = spy(profileService);
+    doThrow(ElementNotFoundException.class).when(spyService).getProfileByEmail(anyString());
+
+    // When
+    Executable executable = () -> spyService.getProfileImage(email);
+
+    // Then
+    assertThrows(ElementNotFoundException.class, executable,
+        "Should throw exception when profile not found");
+  }
+
+  @Test
+  void shouldThrow_When_ReturnProfileImage_When_ProfileImageNull() throws ElementNotFoundException {
+    // Given
+    String email = "test@test.com";
+
+    ProfileService spyService = spy(profileService);
+    doReturn(profile).when(spyService).getProfileByEmail(anyString());
+
+    // When
+    Executable executable = () -> spyService.getProfileImage(email);
+
+    // Then
+    assertThrows(ElementNotFoundException.class, executable,
+        "Should throw exception when profile image not found");
   }
 }

--- a/backend/profile-service/src/test/java/org/maxq/profileservice/service/image/upload/S3ImageUploadServiceTest.java
+++ b/backend/profile-service/src/test/java/org/maxq/profileservice/service/image/upload/S3ImageUploadServiceTest.java
@@ -50,7 +50,8 @@ class S3ImageUploadServiceTest {
     PutObjectResponse putObjectResponse = PutObjectResponse.builder().build();
     BucketOperationResponse operationResponse = new BucketOperationResponse(
         true,
-        -1
+        -1,
+        null
     );
 
     when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class))).thenReturn(putObjectResponse);
@@ -82,7 +83,8 @@ class S3ImageUploadServiceTest {
     DeleteObjectResponse deleteObjectResponse = DeleteObjectResponse.builder().build();
     BucketOperationResponse operationResponse = new BucketOperationResponse(
         true,
-        -1
+        -1,
+        null
     );
 
     when(s3Client.deleteObject(any(DeleteObjectRequest.class))).thenReturn(deleteObjectResponse);

--- a/backend/profile-service/src/test/java/org/maxq/profileservice/service/message/handler/ProfileImageUploadHandlerTest.java
+++ b/backend/profile-service/src/test/java/org/maxq/profileservice/service/message/handler/ProfileImageUploadHandlerTest.java
@@ -252,7 +252,7 @@ class ProfileImageUploadHandlerTest {
         "test.jpeg",
         "test-data".getBytes()
     );
-    BucketOperationResponse response = new BucketOperationResponse(true, -1);
+    BucketOperationResponse response = new BucketOperationResponse(true, -1, null);
 
     when(imageUploadService.uploadImage(file)).thenReturn(response);
 
@@ -272,7 +272,7 @@ class ProfileImageUploadHandlerTest {
         "test.jpeg",
         "test-data".getBytes()
     );
-    BucketOperationResponse response = new BucketOperationResponse(false, 404);
+    BucketOperationResponse response = new BucketOperationResponse(false, 404, null);
 
     when(imageUploadService.uploadImage(file)).thenReturn(response);
 
@@ -379,7 +379,7 @@ class ProfileImageUploadHandlerTest {
   void shouldCleanupOldImage_When_DeleteSuccessful() {
     // Given
     String imageName = "image.jpeg";
-    BucketOperationResponse response = new BucketOperationResponse(true, 200);
+    BucketOperationResponse response = new BucketOperationResponse(true, 200, null);
 
     when(imageUploadService.deleteImage(anyString())).thenReturn(response);
 
@@ -394,7 +394,7 @@ class ProfileImageUploadHandlerTest {
   void shouldCleanupOldImage_When_DeleteFails() {
     // Given
     String imageName = "image.jpeg";
-    BucketOperationResponse response = new BucketOperationResponse(false, 404);
+    BucketOperationResponse response = new BucketOperationResponse(false, 404, null);
 
     when(imageUploadService.deleteImage(anyString())).thenReturn(response);
 


### PR DESCRIPTION
Added an endpoint for serving profile images for frontend.

The endpoint will use authenticated user email to fetch it's profile and if that exists and image from S3 Bucket and serve it as Resource.

Additionally, added ProfileImageService to wrap some image related methods in ProfileController for more atomic operations.